### PR TITLE
build(deck): add PNG-render scripts for visual slide verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "export": "slidev export slides.md",
     "export:3day": "slidev export slides-3day.md --output slides-3day-export",
     "export:templates": "slidev export slides-templates.md --output slides-templates-export",
+    "render": "slidev export slides.md --format png --per-slide --output dist-render",
+    "render:clicks": "slidev export slides.md --format png --per-slide --with-clicks --output dist-render",
+    "render:3day": "slidev export slides-3day.md --format png --per-slide --output dist-render-3day",
     "lint": "markdownlint-cli2",
     "lint:fix": "markdownlint-cli2 --fix"
   },


### PR DESCRIPTION
## What & why

Adds three convenience scripts for **visually verifying slides** via `slidev export` — the render path that catches what `slidev build` can't (text overflow, oversized fonts, animation/click steps, image placement).

```
render        slidev export slides.md --format png --per-slide --output dist-render
render:clicks slidev export slides.md --format png --per-slide --with-clicks --output dist-render
render:3day   slidev export slides-3day.md --format png --per-slide --output dist-render-3day
```

- `--per-slide` renders each slide independently so global components/animations draw correctly.
- `--with-clicks` emits one PNG per click step — needed to verify animations and magic-move.
- Uses the already-bundled `playwright-chromium` (works headless, no extra install).
- Output dirs (`dist-render*`) are covered by the existing `dist-*/` gitignore rule — nothing to commit.

Companion to the `render-slides` agent skill (documents the full workflow + the worktree pnpm gotcha).

## Verification
- `package.json` parses; the three script bodies were smoke-tested (`slidev export … --range 1` → PNG produced).
- No behavior change to existing scripts.

_Tooling-only; separate from the content PR #1 by request._
