### PR TITLE
feat(infra): add the infra/ skeleton — pinned kind cluster, doctor, and make verbs (US-ENV-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
 
+  infra:
+    name: Infra scripts (shellcheck + bats)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Shellcheck infra scripts and test stubs
+        run: |
+          find infra -type f \( -name '*.sh' -o -name '*.bash' \) -print0 | xargs -0 shellcheck
+          shellcheck infra/tests/stubs/*
+      - name: Run bats tests (mocked binaries — no cluster needed)
+        run: bats infra/tests
+
   build:
     name: Build root decks
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Workshop task entrypoint (ADR 0006) — thin verbs only; the logic lives in
+# infra/. Versions come from the single pin file (ADR 0007).
+#
+#   make            # this help
+#   make kind-up    # create the local kind cluster (idempotent)
+#   make kind-down  # delete it (idempotent) — panic reset: kind-down && kind-up
+#   make doctor     # check the environment is lab-ready
+
+include infra/versions.env
+
+.DEFAULT_GOAL := help
+.PHONY: help kind-up kind-down doctor
+
+help: ## Show this help
+	@echo "Workshop environment — usage: make <verb>"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z0-9_-]+:.*## / {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+kind-up: ## Create the local kind cluster from infra/kind/cluster.yaml (idempotent)
+	@if kind get clusters 2>/dev/null | grep -qx '$(WORKSHOP_CLUSTER_NAME)'; then \
+		echo "kind cluster '$(WORKSHOP_CLUSTER_NAME)' already exists — nothing to do"; \
+	else \
+		kind create cluster --name '$(WORKSHOP_CLUSTER_NAME)' --config infra/kind/cluster.yaml --image '$(KIND_NODE_IMAGE)'; \
+	fi
+
+kind-down: ## Delete the local kind cluster (idempotent)
+	@if kind get clusters 2>/dev/null | grep -qx '$(WORKSHOP_CLUSTER_NAME)'; then \
+		kind delete cluster --name '$(WORKSHOP_CLUSTER_NAME)'; \
+	else \
+		echo "no cluster '$(WORKSHOP_CLUSTER_NAME)' — nothing to do"; \
+	fi
+
+doctor: ## Check the environment is lab-ready (engine, cluster, nodes, smoke Pod)
+	@infra/doctor.sh

--- a/infra/doctor.sh
+++ b/infra/doctor.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# infra/doctor.sh — is this machine lab-ready? (ADR 0006)
+#
+# Checks, in dependency order:
+#   1. a container engine (docker or podman) is reachable
+#   2. kind is installed (version compared against the pin — WARN on drift)
+#   3. kubectl is installed (version compared against the pin — WARN on drift)
+#   4. the workshop kind cluster exists
+#   5. the cluster answers the API (kubectl cluster-info)
+#   6. every node is Ready
+#   7. a short-lived smoke Pod runs to completion and is cleaned up
+#
+# Never prompts (it is a check script), so WORKSHOP_NONINTERACTIVE is
+# honoured trivially; set it anyway for symmetry with the other tooling.
+# Exit code: 0 when nothing FAILed (WARNs allowed), 1 otherwise.
+
+set -u
+
+WORKSHOP_NONINTERACTIVE="${WORKSHOP_NONINTERACTIVE:-1}"
+export WORKSHOP_NONINTERACTIVE
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=versions.env disable=SC1091
+. "$script_dir/versions.env"
+
+pass_count=0
+warn_count=0
+fail_count=0
+
+pass() { pass_count=$((pass_count + 1)); echo "[PASS] $1"; }
+warn() { warn_count=$((warn_count + 1)); echo "[WARN] $1"; }
+fail() { fail_count=$((fail_count + 1)); echo "[FAIL] $1"; }
+
+summary_and_exit() {
+  echo ""
+  echo "doctor: ${pass_count} passed, ${warn_count} warnings, ${fail_count} failed"
+  if [ "$fail_count" -gt 0 ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+kube_ctx="kind-${WORKSHOP_CLUSTER_NAME}"
+
+# 1. container engine ---------------------------------------------------------
+engine=""
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  engine="docker"
+elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+  engine="podman"
+fi
+if [ -n "$engine" ]; then
+  pass "container engine reachable ($engine)"
+else
+  fail "no container engine reachable — start Docker Desktop / Podman machine"
+  summary_and_exit
+fi
+
+# 2. kind binary + version vs pin --------------------------------------------
+if command -v kind >/dev/null 2>&1; then
+  kind_actual="$(kind version 2>/dev/null | awk '{print $2}')"
+  if [ "$kind_actual" = "$KIND_VERSION" ]; then
+    pass "kind $kind_actual matches pin ($KIND_VERSION)"
+  else
+    warn "kind is $kind_actual but the workshop is tested with $KIND_VERSION (infra/versions.env)"
+  fi
+else
+  fail "kind not found on PATH — install kind $KIND_VERSION"
+  summary_and_exit
+fi
+
+# 3. kubectl binary + version vs pin ------------------------------------------
+if command -v kubectl >/dev/null 2>&1; then
+  kubectl_actual="$(kubectl version --client 2>/dev/null | awk '/Client Version/{print $3}')"
+  if [ "$kubectl_actual" = "$KUBECTL_VERSION" ]; then
+    pass "kubectl $kubectl_actual matches pin ($KUBECTL_VERSION)"
+  else
+    warn "kubectl is ${kubectl_actual:-unknown} but the workshop is tested with $KUBECTL_VERSION (infra/versions.env)"
+  fi
+else
+  fail "kubectl not found on PATH — install kubectl $KUBECTL_VERSION"
+  summary_and_exit
+fi
+
+# 4. cluster exists ------------------------------------------------------------
+if kind get clusters 2>/dev/null | grep -qx "$WORKSHOP_CLUSTER_NAME"; then
+  pass "kind cluster '$WORKSHOP_CLUSTER_NAME' exists"
+else
+  fail "kind cluster '$WORKSHOP_CLUSTER_NAME' not found — run: make kind-up"
+  summary_and_exit
+fi
+
+# 5. cluster reachable ----------------------------------------------------------
+if kubectl cluster-info --context "$kube_ctx" >/dev/null 2>&1; then
+  pass "cluster answers the API (context $kube_ctx)"
+else
+  fail "cluster '$WORKSHOP_CLUSTER_NAME' is not reachable — panic reset: make kind-down && make kind-up"
+  summary_and_exit
+fi
+
+# 6. nodes Ready ----------------------------------------------------------------
+node_states="$(kubectl --context "$kube_ctx" get nodes \
+  -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null)"
+total=0
+ready=0
+for s in $node_states; do
+  total=$((total + 1))
+  if [ "$s" = "True" ]; then
+    ready=$((ready + 1))
+  fi
+done
+if [ "$total" -gt 0 ] && [ "$ready" -eq "$total" ]; then
+  pass "all nodes Ready ($ready/$total)"
+else
+  fail "nodes Ready: $ready/$total — inspect: kubectl --context $kube_ctx describe nodes"
+  summary_and_exit
+fi
+
+# 7. smoke Pod -------------------------------------------------------------------
+smoke_pod="workshop-doctor-smoke"
+cleanup_smoke() {
+  kubectl --context "$kube_ctx" delete pod "$smoke_pod" \
+    --ignore-not-found --wait=false >/dev/null 2>&1
+}
+trap cleanup_smoke EXIT
+
+if kubectl --context "$kube_ctx" run "$smoke_pod" \
+  --image="$WORKSHOP_SMOKE_IMAGE" --restart=Never \
+  --command -- /agnhost help >/dev/null 2>&1 &&
+  kubectl --context "$kube_ctx" wait \
+    --for=jsonpath='{.status.phase}'=Succeeded "pod/$smoke_pod" \
+    --timeout=60s >/dev/null 2>&1; then
+  pass "smoke Pod ran to completion and was cleaned up"
+else
+  fail "smoke Pod did not complete — the cluster cannot run workloads; panic reset: make kind-down && make kind-up"
+fi
+cleanup_smoke
+
+summary_and_exit

--- a/infra/kind/cluster.yaml
+++ b/infra/kind/cluster.yaml
@@ -1,0 +1,31 @@
+# Local workshop cluster (ADR 0006) — single node; every lab is
+# single-node-safe.
+#
+# NOTE: the node image is intentionally NOT set here. kind configs cannot
+# interpolate variables, so the Makefile passes `--image` from the digest
+# pin in infra/versions.env (`make kind-up`). Do not add an `image:` field —
+# it would silently shadow the pin.
+#
+# The cluster name must match WORKSHOP_CLUSTER_NAME in infra/versions.env.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: workshop
+nodes:
+  - role: control-plane
+    # Label the node so ingress/gateway controllers that select
+    # `ingress-ready=true` (the standard kind pattern) schedule here.
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    # Publish 80/443 on the host so the ingress (day 1) and Gateway API
+    # (day 2) labs can curl http://localhost without port-forwards.
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP

--- a/infra/tests/README.md
+++ b/infra/tests/README.md
@@ -1,0 +1,17 @@
+# infra tests
+
+Unit tests for the root `Makefile` verbs and `infra/doctor.sh`, written for
+[bats-core](https://github.com/bats-core/bats-core). No cluster and no
+container engine are needed: `stubs/` provides mock `kind` / `kubectl` /
+`docker` / `podman` binaries that record every invocation to `$MOCK_LOG` and
+fake their responses via `MOCK_*` environment variables (see each stub's
+header comment).
+
+Run from the repo root:
+
+```sh
+bats infra/tests
+```
+
+CI runs the same suite plus `shellcheck` over the infra scripts on every
+push/PR (see `.github/workflows/ci.yml`).

--- a/infra/tests/doctor.bats
+++ b/infra/tests/doctor.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# Unit tests for infra/doctor.sh, run against mocked binaries
+# (infra/tests/stubs). No real cluster or container engine is touched.
+
+load helpers
+
+setup() {
+  setup_mocks
+  chmod +x "$ROOT"/infra/tests/stubs/* "$ROOT/infra/doctor.sh"
+  export WORKSHOP_NONINTERACTIVE=1
+}
+
+@test "doctor passes when engine, cluster, nodes, and smoke Pod are green" {
+  export MOCK_CLUSTER_EXISTS=1
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "0 failed"
+  # the smoke Pod must be cleaned up
+  grep -q "kubectl.*delete pod" "$MOCK_LOG"
+}
+
+@test "doctor fails cleanly when the cluster is missing" {
+  export MOCK_CLUSTER_EXISTS=0
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "FAIL"
+  echo "$output" | grep -q "make kind-up"
+}
+
+@test "doctor fails when no container engine is reachable" {
+  export MOCK_CLUSTER_EXISTS=1
+  export MOCK_ENGINE_UP=0
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "FAIL"
+}
+
+@test "doctor warns but does not fail on a kind version mismatch" {
+  export MOCK_CLUSTER_EXISTS=1
+  export MOCK_KIND_VERSION=v0.20.0
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "WARN"
+}
+
+@test "doctor fails when nodes are not Ready" {
+  export MOCK_CLUSTER_EXISTS=1
+  export MOCK_NODES_READY=0
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "FAIL"
+}
+
+@test "doctor fails when the smoke Pod does not complete" {
+  export MOCK_CLUSTER_EXISTS=1
+  export MOCK_SMOKE_EXIT=1
+  run "$ROOT/infra/doctor.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "FAIL"
+  # even a failed smoke Pod must be cleaned up
+  grep -q "kubectl.*delete pod" "$MOCK_LOG"
+}

--- a/infra/tests/helpers.bash
+++ b/infra/tests/helpers.bash
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+# Shared bats helpers: point PATH at the mock binaries and load the pin file
+# so assertions can never drift from infra/versions.env.
+
+repo_root() {
+  cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd
+}
+
+setup_mocks() {
+  ROOT="$(repo_root)"
+  export ROOT
+
+  # Every stub appends its invocation here; tests assert against it.
+  MOCK_LOG="$BATS_TEST_TMPDIR/mock.log"
+  : > "$MOCK_LOG"
+  export MOCK_LOG
+
+  PATH="$ROOT/infra/tests/stubs:$PATH"
+  export PATH
+
+  # Load the pins (KIND_VERSION, KIND_NODE_IMAGE, ...) for assertions.
+  # shellcheck source=../versions.env disable=SC1091
+  . "$ROOT/infra/versions.env"
+}

--- a/infra/tests/makefile.bats
+++ b/infra/tests/makefile.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# Unit tests for the root Makefile verbs, run against mocked binaries
+# (infra/tests/stubs). No real cluster or container engine is touched.
+
+load helpers
+
+setup() {
+  setup_mocks
+  chmod +x "$ROOT"/infra/tests/stubs/*
+}
+
+@test "kind-up creates the cluster with the pinned node image and config" {
+  export MOCK_CLUSTER_EXISTS=0
+  run make -C "$ROOT" kind-up
+  [ "$status" -eq 0 ]
+  grep -q -- "kind create cluster --name ${WORKSHOP_CLUSTER_NAME} --config infra/kind/cluster.yaml --image ${KIND_NODE_IMAGE}" "$MOCK_LOG"
+}
+
+@test "kind-up is idempotent when the cluster already exists" {
+  export MOCK_CLUSTER_EXISTS=1
+  run make -C "$ROOT" kind-up
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "already exists"
+  ! grep -q "kind create" "$MOCK_LOG"
+}
+
+@test "kind-down deletes the cluster by name" {
+  export MOCK_CLUSTER_EXISTS=1
+  run make -C "$ROOT" kind-down
+  [ "$status" -eq 0 ]
+  grep -q -- "kind delete cluster --name ${WORKSHOP_CLUSTER_NAME}" "$MOCK_LOG"
+}
+
+@test "kind-down is idempotent when no cluster exists" {
+  export MOCK_CLUSTER_EXISTS=0
+  run make -C "$ROOT" kind-down
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "no cluster"
+  ! grep -q "kind delete" "$MOCK_LOG"
+}
+
+@test "doctor verb runs infra/doctor.sh" {
+  export MOCK_CLUSTER_EXISTS=1
+  run make -C "$ROOT" doctor
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "doctor:"
+}
+
+@test "help is the default goal and lists the verbs" {
+  run make -C "$ROOT"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "kind-up"
+  echo "$output" | grep -q "kind-down"
+  echo "$output" | grep -q "doctor"
+}

--- a/infra/tests/stubs/docker
+++ b/infra/tests/stubs/docker
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Mock `docker` for bats tests. Records every invocation to $MOCK_LOG.
+#   MOCK_ENGINE_UP=0 -> `docker info` fails (engine unreachable)
+set -eu
+
+echo "docker $*" >> "${MOCK_LOG:?stub requires MOCK_LOG}"
+
+if [ "${MOCK_ENGINE_UP:-1}" != "1" ]; then
+  exit 1
+fi

--- a/infra/tests/stubs/kind
+++ b/infra/tests/stubs/kind
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Mock `kind` for bats tests. Records every invocation to $MOCK_LOG and
+# fakes responses driven by MOCK_* environment variables:
+#   MOCK_CLUSTER_EXISTS=1  -> `kind get clusters` lists the workshop cluster
+#   MOCK_KIND_VERSION=...  -> version string reported by `kind version`
+#   MOCK_KIND_EXIT=N       -> exit code for create/delete
+set -eu
+
+echo "kind $*" >> "${MOCK_LOG:?stub requires MOCK_LOG}"
+
+case "${1:-}" in
+  version)
+    echo "kind ${MOCK_KIND_VERSION:-v0.32.0} go1.24.4 linux/amd64"
+    ;;
+  get)
+    # `kind get clusters`
+    if [ "${MOCK_CLUSTER_EXISTS:-0}" = "1" ]; then
+      echo "workshop"
+    fi
+    ;;
+  create | delete)
+    exit "${MOCK_KIND_EXIT:-0}"
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/infra/tests/stubs/kubectl
+++ b/infra/tests/stubs/kubectl
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Mock `kubectl` for bats tests. Records every invocation to $MOCK_LOG and
+# fakes responses driven by MOCK_* environment variables:
+#   MOCK_KUBECTL_VERSION=...        -> client version string
+#   MOCK_CLUSTER_REACHABLE_EXIT=N   -> exit code for `kubectl cluster-info`
+#   MOCK_NODES_READY=0              -> nodes report NotReady
+#   MOCK_SMOKE_EXIT=N               -> exit code for `kubectl wait` (smoke Pod)
+set -eu
+
+echo "kubectl $*" >> "${MOCK_LOG:?stub requires MOCK_LOG}"
+
+# Strip global flags (--context <name>) so the verb lands in $1.
+args=()
+skip_next=0
+for a in "$@"; do
+  if [ "$skip_next" = "1" ]; then skip_next=0; continue; fi
+  case "$a" in
+    --context) skip_next=1 ;;
+    *) args+=("$a") ;;
+  esac
+done
+
+case "${args[0]:-}" in
+  version)
+    echo "Client Version: ${MOCK_KUBECTL_VERSION:-v1.36.1}"
+    ;;
+  cluster-info)
+    exit "${MOCK_CLUSTER_REACHABLE_EXIT:-0}"
+    ;;
+  get)
+    # doctor asks for per-node Ready condition status lines
+    if [ "${MOCK_NODES_READY:-1}" = "1" ]; then
+      echo "True"
+    else
+      echo "False"
+    fi
+    ;;
+  wait)
+    exit "${MOCK_SMOKE_EXIT:-0}"
+    ;;
+  run | delete)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/infra/tests/stubs/podman
+++ b/infra/tests/stubs/podman
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Mock `podman` for bats tests — same contract as the docker stub, so a
+# machine with a real podman on PATH cannot leak into the engine check.
+#   MOCK_ENGINE_UP=0 -> `podman info` fails (engine unreachable)
+set -eu
+
+echo "podman $*" >> "${MOCK_LOG:?stub requires MOCK_LOG}"
+
+if [ "${MOCK_ENGINE_UP:-1}" != "1" ]; then
+  exit 1
+fi

--- a/infra/versions.env
+++ b/infra/versions.env
@@ -1,0 +1,40 @@
+# infra/versions.env — THE pin file (ADR 0007).
+#
+# Every reproducibility-critical version for the workshop environment is set
+# here and nowhere else. This file is both `include`d by the root Makefile
+# and sourced by infra/*.sh, so keep it to plain KEY=value lines: no spaces
+# around `=`, no quoting, no shell expansion.
+#
+# Review cadence (ADR 0007): bump to current stable before each delivery and
+# at minimum once per Kubernetes minor release cycle, then re-run the full
+# validation pass (`make doctor`, bats, lab smoke).
+
+# kind CLI release the environment is tested with.
+# Source: https://github.com/kubernetes-sigs/kind/releases (v0.32.0, latest
+# stable at pin time, 2026-07-11). doctor.sh warns on a mismatched local kind.
+KIND_VERSION=v0.32.0
+
+# kind node image — pinned BY DIGEST, taken verbatim from the kind v0.32.0
+# release notes ("The default node image is now ..."):
+# https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0
+# This digest fixes the Kubernetes version for the local lane (v1.36.1).
+# Never use a bare tag here: per upstream, only the digest guarantees an
+# image built for a specific kind release.
+KIND_NODE_IMAGE=kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+
+# kubectl client version matching the pinned cluster (same Kubernetes
+# release as the node image; within the supported +/-1 minor skew).
+# Source: https://github.com/kubernetes/kubernetes/releases (v1.36.1).
+KUBECTL_VERSION=v1.36.1
+
+# Image for doctor.sh's 5-second smoke Pod — the Kubernetes project's own
+# e2e test image (multi-arch, vendor-neutral), pinned by digest.
+# Tag list + manifest digest read from registry.k8s.io
+# (/v2/e2e-test-images/agnhost/manifests/2.66.0, docker-content-digest
+# header) on 2026-07-11.
+WORKSHOP_SMOKE_IMAGE=registry.k8s.io/e2e-test-images/agnhost:2.66.0@sha256:e518c9d629672720031c601b9aaa83e218ecf5821aff5cc16ac972e109096540
+
+# Not a version, but shared config the Makefile and doctor.sh both need.
+# Must match `name:` in infra/kind/cluster.yaml (kind configs cannot
+# interpolate variables).
+WORKSHOP_CLUSTER_NAME=workshop


### PR DESCRIPTION
## What

Creates the `infra/` tree ADR 0006 promised (audit finding **AR-07**): seven Day-2 labs already tell participants `make kind-down && make kind-up` is the panic reset — this PR makes those commands real.

- `infra/versions.env` — pin file: kind **v0.32.0**, `kindest/node:v1.36.1` **pinned by digest** (verbatim from the kind v0.32.0 release notes), kubectl v1.36.1, agnhost smoke image digest-pinned from registry.k8s.io
- `infra/kind/cluster.yaml` — single-node cluster `workshop`, 80/443 extraPortMappings for the ingress/gateway labs
- `infra/doctor.sh` — engine/binary/cluster/nodes checks + a 5s agnhost smoke Pod with guaranteed cleanup; `WORKSHOP_NONINTERACTIVE=1`-safe; version drift WARNs, functional failures exit non-zero
- root `Makefile` — `help` (default) / `kind-up` / `kind-down` / `doctor`, idempotent in both cluster states, image passed `--image` from the pin file
- `infra/tests/` — 12 bats tests against mocked kind/kubectl/docker/podman binaries
- CI — additive `infra` job (shellcheck + bats); existing jobs byte-identical

Out of scope by design: addons (US-ENV-3), mise/bootstrap (US-ENV-2), `package.json` (owned by #2).

## Gates

shellcheck 0 findings · bats 12/12 · `make -n` dry-runs show the digest-pinned invocation · `pnpm build` green · markdownlint 0 errors · both pins verified against upstream sources.

## Review

Tech review @ `7f2ba6d`: **APPROVE** — all gates re-run independently, pins verified byte-exact (kind release notes; registry.k8s.io `docker-content-digest`), labs-consistency check confirms the seven Day-2 labs' verbs and Lab 09's `--name workshop` assumption match, guardrail scan clean (no brands, no tooling attribution, no nginx). Non-blocking P3 notes: empty bookkeeping commit `7f2ba6d` (squash-merge drops it); kind-up/down logic inline in the Makefile vs ADR 0006's 'logic lives in infra/' sketch (extract or amend with US-ENV-3); doctor smoke cleanup uses `--wait=false` so an immediate re-run can hit the still-terminating pod; `infra/README.md` still owed by a later story.