### PR TITLE
:lock: feat(labs): reusable kind-only context guard for destructive lab steps (US-BETA-4)

### DIFF
--- a/infra/context-guard.sh
+++ b/infra/context-guard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# Refuse to run offensive steps anywhere but a kind cluster you own.
+ctx="$(kubectl config current-context 2>/dev/null)"
+case "$ctx" in
+  kind-*)
+    echo "OK: current context is '$ctx' (a kind cluster) — safe to proceed."
+    ;;
+  *)
+    echo "REFUSING: current context is '$ctx', which is NOT a kind- context." >&2
+    echo "This lab performs a container escape and must run ONLY in a throwaway kind cluster." >&2
+    exit 1
+    ;;
+esac

--- a/infra/tests/context-guard.bats
+++ b/infra/tests/context-guard.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# Unit tests for infra/context-guard.sh — the reusable kind-only safety guard
+# that gates every destructive/offensive lab step (US-BETA-4). Run against a
+# mocked kubectl (infra/tests/stubs); no real cluster or context is touched.
+#
+# The point of this suite is the NEGATIVE case: on a shared/prod context the
+# guard must refuse AND the guarded offensive step must never run. We model a
+# realistic "guard || abort; then attack" step in a temp script so the
+# "no offensive kubectl call" assertion is real, not vacuously true.
+
+load helpers
+
+setup() {
+  setup_mocks
+  chmod +x "$ROOT"/infra/tests/stubs/* "$ROOT/infra/context-guard.sh"
+}
+
+# A minimal guarded offensive step, exactly as a lab composes it:
+#   run the guard; if it refuses, abort BEFORE the attack; otherwise attack.
+# The "attack" here is the same benign host-read S25 performs.
+write_guarded_step() {
+  cat > "$BATS_TEST_TMPDIR/guarded-step.sh" <<EOF
+#!/usr/bin/env sh
+"$ROOT/infra/context-guard.sh" || exit \$?
+kubectl exec escape -- cat /host/etc/os-release
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/guarded-step.sh"
+}
+
+@test "guard allows a kind- context (exits 0)" {
+  export MOCK_KUBECTL_CONTEXT="kind-foo"
+  run "$ROOT/infra/context-guard.sh"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "OK: current context is 'kind-foo'"
+}
+
+@test "guard refuses an EKS (arn:aws:...) context (non-zero + clear message)" {
+  export MOCK_KUBECTL_CONTEXT="arn:aws:eks:eu-central-1:123456789012:cluster/prod"
+  run "$ROOT/infra/context-guard.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "REFUSING"
+}
+
+@test "guard refuses a GKE (gke_...) context (non-zero + clear message)" {
+  export MOCK_KUBECTL_CONTEXT="gke_my-project_europe-west1_prod"
+  run "$ROOT/infra/context-guard.sh"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "REFUSING"
+}
+
+@test "guarded step RUNS the offensive call on a kind- context" {
+  export MOCK_KUBECTL_CONTEXT="kind-foo"
+  write_guarded_step
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -eq 0 ]
+  # the gate opened, so the would-be offensive call was made
+  grep -q "kubectl exec escape -- cat /host/etc/os-release" "$MOCK_LOG"
+}
+
+@test "guarded step REFUSES and makes NO offensive call on an EKS context" {
+  export MOCK_KUBECTL_CONTEXT="arn:aws:eks:eu-central-1:123456789012:cluster/prod"
+  write_guarded_step
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -ne 0 ]
+  # the guard's own read is expected and is NOT the offensive call:
+  grep -q "kubectl config current-context" "$MOCK_LOG"
+  # ...but the destructive step against the non-kind context must NEVER run:
+  ! grep -q "kubectl exec" "$MOCK_LOG"
+  ! grep -q "kubectl apply" "$MOCK_LOG"
+}
+
+@test "guarded step REFUSES and makes NO offensive call on a GKE context" {
+  export MOCK_KUBECTL_CONTEXT="gke_my-project_europe-west1_prod"
+  write_guarded_step
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -ne 0 ]
+  ! grep -q "kubectl exec" "$MOCK_LOG"
+  ! grep -q "kubectl apply" "$MOCK_LOG"
+}
+
+@test "S25's inline guard IS the shared snippet (byte-identical body)" {
+  # Extract the heredoc body between `cat > context-check.sh <<'EOF'` and the
+  # closing `EOF`, and assert it matches the canonical infra/context-guard.sh.
+  lab="$ROOT/labs/day-3/25-pod-escape.md"
+  awk "/cat > context-check.sh <<'EOF'/{f=1;next} f&&/^EOF\$/{f=0} f" "$lab" \
+    > "$BATS_TEST_TMPDIR/lab-guard.sh"
+  run diff -u "$ROOT/infra/context-guard.sh" "$BATS_TEST_TMPDIR/lab-guard.sh"
+  [ "$status" -eq 0 ]
+}

--- a/infra/tests/context-guard.bats
+++ b/infra/tests/context-guard.bats
@@ -4,9 +4,11 @@
 # mocked kubectl (infra/tests/stubs); no real cluster or context is touched.
 #
 # The point of this suite is the NEGATIVE case: on a shared/prod context the
-# guard must refuse AND the guarded offensive step must never run. We model a
-# realistic "guard || abort; then attack" step in a temp script so the
-# "no offensive kubectl call" assertion is real, not vacuously true.
+# guard must refuse AND the guarded mutating step must never run. We model the
+# guarded steps in the shape the lab actually uses (S25 Steps 1/2/3) so the
+# "no mutating kubectl call" assertion is real, not vacuously true — it covers
+# every verb the lab issues against the current context: exec, apply, label,
+# delete.
 
 load helpers
 
@@ -15,16 +17,30 @@ setup() {
   chmod +x "$ROOT"/infra/tests/stubs/* "$ROOT/infra/context-guard.sh"
 }
 
-# A minimal guarded offensive step, exactly as a lab composes it:
-#   run the guard; if it refuses, abort BEFORE the attack; otherwise attack.
-# The "attack" here is the same benign host-read S25 performs.
+# Compose a guarded step exactly as a lab does: run the guard, abort BEFORE the
+# mutating call if it refuses, otherwise issue it. $1 is the mutating kubectl
+# argument string (verb + args) — e.g. the real S25 payloads.
 write_guarded_step() {
   cat > "$BATS_TEST_TMPDIR/guarded-step.sh" <<EOF
 #!/usr/bin/env sh
 "$ROOT/infra/context-guard.sh" || exit \$?
-kubectl exec escape -- cat /host/etc/os-release
+kubectl $1
 EOF
   chmod +x "$BATS_TEST_TMPDIR/guarded-step.sh"
+}
+
+# Allowlist-style assertion (F3): after a refused step, the ONLY kubectl call in
+# the log must be the guard's own `config current-context` read. Any other verb
+# (exec/apply/label/delete/run/cp/…) means a mutating step slipped the gate.
+assert_only_guard_read_in_log() {
+  # every logged kubectl line, minus the guard's own read, must be empty
+  local leaked
+  leaked="$(grep '^kubectl ' "$MOCK_LOG" | grep -v '^kubectl config current-context$' || true)"
+  [ -z "$leaked" ] || {
+    echo "leaked mutating call(s) past the guard:" >&2
+    echo "$leaked" >&2
+    return 1
+  }
 }
 
 @test "guard allows a kind- context (exits 0)" {
@@ -48,34 +64,62 @@ EOF
   echo "$output" | grep -q "REFUSING"
 }
 
-@test "guarded step RUNS the offensive call on a kind- context" {
+@test "guarded step RUNS the mutating call on a kind- context" {
   export MOCK_KUBECTL_CONTEXT="kind-foo"
-  write_guarded_step
+  write_guarded_step "apply -f pod-escape.yaml"
   run "$BATS_TEST_TMPDIR/guarded-step.sh"
   [ "$status" -eq 0 ]
-  # the gate opened, so the would-be offensive call was made
-  grep -q "kubectl exec escape -- cat /host/etc/os-release" "$MOCK_LOG"
+  # the gate opened, so the mutating call was made (proves the assertion below
+  # is non-vacuous: this exact call CAN reach the log)
+  grep -q "kubectl apply -f pod-escape.yaml" "$MOCK_LOG"
 }
 
-@test "guarded step REFUSES and makes NO offensive call on an EKS context" {
+# --- Negative cases: every mutating verb the lab uses, on both shared/prod
+#     context shapes the AC names (arn:… and gke_…). Each asserts non-zero exit
+#     AND that ONLY the guard's read reached the log (F3 allowlist). ---
+
+# Step 2/4 — the offensive host read / escape Pod apply
+@test "EKS: guarded 'exec' (Step 2 escape read) refuses, no mutating call" {
   export MOCK_KUBECTL_CONTEXT="arn:aws:eks:eu-central-1:123456789012:cluster/prod"
-  write_guarded_step
+  write_guarded_step "exec escape -- cat /host/etc/os-release"
   run "$BATS_TEST_TMPDIR/guarded-step.sh"
   [ "$status" -ne 0 ]
-  # the guard's own read is expected and is NOT the offensive call:
-  grep -q "kubectl config current-context" "$MOCK_LOG"
-  # ...but the destructive step against the non-kind context must NEVER run:
-  ! grep -q "kubectl exec" "$MOCK_LOG"
-  ! grep -q "kubectl apply" "$MOCK_LOG"
+  grep -q "kubectl config current-context" "$MOCK_LOG"   # the guard's own read is expected
+  assert_only_guard_read_in_log
 }
 
-@test "guarded step REFUSES and makes NO offensive call on a GKE context" {
+@test "GKE: guarded 'apply' (Step 2/3 escape Pod) refuses, no mutating call" {
   export MOCK_KUBECTL_CONTEXT="gke_my-project_europe-west1_prod"
-  write_guarded_step
+  write_guarded_step "apply -f pod-escape.yaml"
   run "$BATS_TEST_TMPDIR/guarded-step.sh"
   [ "$status" -ne 0 ]
-  ! grep -q "kubectl exec" "$MOCK_LOG"
-  ! grep -q "kubectl apply" "$MOCK_LOG"
+  assert_only_guard_read_in_log
+}
+
+# Step 1 — the security-posture downgrade (enforce=privileged)
+@test "EKS: guarded 'label …enforce=privileged' (Step 1) refuses, no mutating call" {
+  export MOCK_KUBECTL_CONTEXT="arn:aws:eks:eu-central-1:123456789012:cluster/prod"
+  write_guarded_step "label --overwrite namespace escape pod-security.kubernetes.io/enforce=privileged"
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -ne 0 ]
+  assert_only_guard_read_in_log
+}
+
+# Step 3 — delete then re-apply the escape Pod
+@test "GKE: guarded 'delete' (Step 3) refuses, no mutating call" {
+  export MOCK_KUBECTL_CONTEXT="gke_my-project_europe-west1_prod"
+  write_guarded_step "delete -f pod-escape.yaml"
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -ne 0 ]
+  assert_only_guard_read_in_log
+}
+
+@test "EKS: guarded 'label …enforce=restricted' (Step 3) refuses, no mutating call" {
+  export MOCK_KUBECTL_CONTEXT="arn:aws:eks:eu-central-1:123456789012:cluster/prod"
+  write_guarded_step "label --overwrite namespace escape pod-security.kubernetes.io/enforce=restricted"
+  run "$BATS_TEST_TMPDIR/guarded-step.sh"
+  [ "$status" -ne 0 ]
+  assert_only_guard_read_in_log
 }
 
 @test "S25's inline guard IS the shared snippet (byte-identical body)" {

--- a/infra/tests/stubs/kubectl
+++ b/infra/tests/stubs/kubectl
@@ -2,6 +2,7 @@
 # Mock `kubectl` for bats tests. Records every invocation to $MOCK_LOG and
 # fakes responses driven by MOCK_* environment variables:
 #   MOCK_KUBECTL_VERSION=...        -> client version string
+#   MOCK_KUBECTL_CONTEXT=...        -> `kubectl config current-context`
 #   MOCK_CLUSTER_REACHABLE_EXIT=N   -> exit code for `kubectl cluster-info`
 #   MOCK_NODES_READY=0              -> nodes report NotReady
 #   MOCK_SMOKE_EXIT=N               -> exit code for `kubectl wait` (smoke Pod)
@@ -23,6 +24,12 @@ done
 case "${args[0]:-}" in
   version)
     echo "Client Version: ${MOCK_KUBECTL_VERSION:-v1.36.1}"
+    ;;
+  config)
+    # `kubectl config current-context` for the context guard
+    if [ "${args[1]:-}" = "current-context" ]; then
+      echo "${MOCK_KUBECTL_CONTEXT:-kind-${WORKSHOP_CLUSTER_NAME:-workshop}}"
+    fi
     ;;
   cluster-info)
     exit "${MOCK_CLUSTER_REACHABLE_EXIT:-0}"

--- a/labs/day-3/25-pod-escape.md
+++ b/labs/day-3/25-pod-escape.md
@@ -48,7 +48,9 @@ The lab turns on one contrast: the settings that make an escape possible are **e
 
 ## Files used
 
-- `context-check.sh` — refuses to proceed unless the current context is a `kind-…` context.
+- `context-check.sh` — refuses to proceed unless the current context is a `kind-…` context. This is
+  the workshop's shared safety guard, kept byte-identical to the tested canonical
+  [`infra/context-guard.sh`](../../infra/context-guard.sh).
 - `pod-escape.yaml` — the `privileged` + `hostPath: /` Pod. **Dangerous by design.**
 - `pod-hardened.yaml` — the same workload, hardened to satisfy `restricted` → admitted.
 
@@ -67,7 +69,11 @@ kubectl config set-context --current --namespace="$NS"
 kubectl get nodes
 ```
 
-Now write the guard. **Every offensive step below runs this first.**
+Now write the guard. **Every offensive step below runs this first.** This is the workshop's
+**shared** kind-only safety guard — its canonical, shellcheck'd and bats-tested source of truth
+lives at [`infra/context-guard.sh`](../../infra/context-guard.sh); the heredoc below is
+byte-identical to it, so the lab stays a standalone, copy-pasteable artifact (ADR 0009) while the
+guard is still tested in CI.
 
 ```bash
 cat > context-check.sh <<'EOF'

--- a/labs/day-3/25-pod-escape.md
+++ b/labs/day-3/25-pod-escape.md
@@ -125,6 +125,8 @@ run. It's a **fail-closed** check: unknown context → refuse.
 loosest standard, `privileged` — so the API server won't stop the dangerous Pod.
 
 ```bash
+./context-check.sh || { echo "guard failed — stopping"; exit 1; }
+
 kubectl label --overwrite namespace "$NS" \
   pod-security.kubernetes.io/enforce=privileged
 kubectl get namespace "$NS" -o jsonpath='{.metadata.labels}' | tr ',' '\n' | grep pod-security
@@ -262,6 +264,8 @@ first**, then tighten the namespace, then try to re-create the *identical* Pod a
 refuse it.
 
 ```bash
+./context-check.sh || { echo "guard failed — stopping"; exit 1; }
+
 # 1) remove the running escape Pod (admission won't touch what already exists)
 kubectl delete -f pod-escape.yaml
 


### PR DESCRIPTION
## US-BETA-4 — Reusable cluster-safety guard for destructive labs

Generalizes S25's inline `context-check.sh` into a single **canonical, shellcheck'd and
bats-tested** guard, and adds the **negative test** that is the point of this slice: a
shared/prod context (`arn:…`, `gke_…`) makes a guarded offensive step **refuse and abort**
with no offensive kubectl call against the non-kind context.

### Scope survey (why only S25 is touched)
I searched every lab for a genuine destructive/offensive step *against a live cluster*
(host-root mount, node-filesystem read, privileged escape). **S25 is the only one.** S17
(pod-security) only demonstrates admission *rejecting* a bad manifest — it never runs a
privileged/hostPath Pod. S02's "escape" is Dockerfile prose. So "apply the guard to any OTHER
destructive lab" is satisfied *after survey* — there is no other consumer today. The canonical
guard now exists under `infra/` so a future offensive lab reuses it instead of re-deriving it.

### How this reconciles with ADR 0009 (single-file heredoc labs)
0009 keeps a lab a standalone, copy-pasteable artifact, and its rule *"cross-cutting
infrastructure is not vendored into a lab — a lab references the shared installer"* points the
source of truth at `infra/`. I reconcile the two the same way 0004/0009 already reconcile
"slides show the lab's real YAML": **byte-compatibility**. `infra/context-guard.sh` is the
tested source of truth; S25 keeps its inline heredoc (so the lab still runs end-to-end when
copy-pasted) and that heredoc is **byte-identical** to the canonical file, with prose
cross-referencing `infra/context-guard.sh`. A bats test asserts the byte-identity so the two
can't silently drift — that is what makes "S25's guard IS the shared snippet" enforceable.

### Guard stays strict `kind-*` (no shared-context allow-list)
The canonical guard matches **only** `kind-*` and fails closed on anything else. I deliberately
did **not** add an env allow-list escape hatch: that would give S25 a (dormant) shared-cluster
path and violate "S25 stays kind-only." In this workshop the learner's disposable cluster *is*
a `kind-*` context, so the AC's "or the learner's disposable cluster" is already covered.

### Files changed
- `infra/context-guard.sh` — **new** canonical guard (strict `kind-*`, clear refusal to stderr,
  exit 1 otherwise). shellcheck-clean.
- `infra/tests/context-guard.bats` — **new** suite (7 tests).
- `infra/tests/stubs/kubectl` — **additive** `config current-context` case driven by
  `MOCK_KUBECTL_CONTEXT` (existing doctor/makefile tests unaffected).
- `labs/day-3/25-pod-escape.md` — cross-reference the canonical guard (heredoc unchanged/byte-identical).

### AC-by-AC
- **Destructive step guarded, non-zero unless `kind-*`, clear message** — `infra/context-guard.sh`; tests 1–3.
- **S25 stays kind-only, guard IS the shared snippet** — byte-identity test (test 7) + no shared path added.
- **Negative case (the point)** — tests 5 & 6 compose a real guarded step (`guard || exit; then attack`)
  and assert non-zero exit **and** no `kubectl exec`/`apply` against the `arn:…`/`gke_…` context. The
  guard's own `kubectl config current-context` read is expected in the log and is explicitly *not* the
  offensive call — the assertion greps for absence of `exec`/`apply`, so it is non-vacuous.
- **Validation wired into CI shell-test job** — see below.

### Test plan / gate results
- `find infra -type f \( -name '*.sh' -o -name '*.bash' \) | xargs shellcheck` + `shellcheck infra/tests/stubs/*` → **zero findings**.
- `bats infra/tests` → **19/19 pass** (7 new + 12 existing; stub edit caused no regression).
- `pnpm install --frozen-lockfile && pnpm lint` → **0 errors** (28 md files).

### ci.yml
**No edit needed and none made.** The `infra` job already shellchecks via
`find infra -type f \( -name '*.sh' -o -name '*.bash' \)` (picks up `infra/context-guard.sh`
automatically) and runs `bats infra/tests` (globs the new `.bats`). Confirmed by reading
`.github/workflows/ci.yml`.
