### PR TITLE
:memo: docs(beta): beta-feedback template + rehearsal checklist + timing template (US-BETA-5)

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/beta-feedback.yml
@@ -1,0 +1,166 @@
+name: Beta feedback
+description: Report feedback on a workshop section or lab from a beta run or rehearsal.
+title: "[beta] <section/lab>: <one-line summary>"
+labels:
+  - beta-feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us harden the workshop. Please file **one issue per
+        section/lab** so feedback stays actionable. If your feedback is
+        cross-cutting (spans several sections), say so in the summary and pick
+        the closest section below.
+
+        The six feedback dimensions below map to how we judge a lab: was it
+        **clear**, were the **commands correct**, did the **time** match, did
+        **prerequisites** hold, was the **learning difficulty** right, and was
+        the **visual quality** (slides/diagrams) good.
+  - type: dropdown
+    id: section
+    attributes:
+      label: Section / lab
+      description: Which section or lab is this feedback about? IDs match the syllabus (S00–S27).
+      options:
+        - "S00 — Welcome & setup (labs/day-1/00-setup.md)"
+        - "S01 — Containers (labs/day-1/01-containers.md)"
+        - "S02 — Container security & supply chain (labs/day-1/02-container-security.md)"
+        - "S03 — Kubernetes mental model (labs/day-1/03-cluster-tour.md)"
+        - "S04 — kubectl (labs/day-1/04-kubectl.md)"
+        - "S05 — Pod (labs/day-1/05-pod.md)"
+        - "S06 — Deployment (labs/day-1/06-deployment.md)"
+        - "S07 — Service (labs/day-1/07-service.md)"
+        - "S08 — Ingress (labs/day-1/08-ingress.md)"
+        - "S09 — Gateway API (labs/day-2/09-gateway-api.md)"
+        - "S10 — ConfigMap & Secret (labs/day-2/10-config.md)"
+        - "S11 — Storage (labs/day-2/11-storage.md)"
+        - "S12 — StatefulSet (labs/day-2/12-statefulset.md)"
+        - "S13 — Resources & limits (labs/day-2/13-resources.md)"
+        - "S14 — Health probes (labs/day-2/14-probes.md)"
+        - "S15 — Jobs & CronJobs (labs/day-2/15-jobs.md)"
+        - "S16 — Autoscaling / HPA (labs/day-2/16-hpa.md)"
+        - "S17 — Pod security (labs/day-3/17-pod-security.md)"
+        - "S18 — NetworkPolicy (labs/day-3/18-networkpolicy.md)"
+        - "S19 — RBAC (labs/day-3/19-rbac.md)"
+        - "S20 — Helm (labs/day-3/20-helm.md)"
+        - "S21 — GitOps with Argo CD (labs/day-3/21-gitops.md)"
+        - "S22 — The operator pattern (labs/day-3/22-operator-concept.md)"
+        - "S23 — Prometheus Operator (labs/day-3/23-prometheus.md)"
+        - "S24 — Operator dev 101 / kubebuilder — DEFERRED STUB (labs/day-3/24-kubebuilder.md)"
+        - "S25 — Security & pod escape (labs/day-3/25-pod-escape.md)"
+        - "S26 — Best practices / capstone (labs/day-3/26-capstone.md)"
+        - "S27 — Wrap-up & next steps (slides only, no lab)"
+        - "Cross-cutting / not tied to one section"
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Which lab environment did you run this in?
+      options:
+        - "Local kind"
+        - "Shared namespace"
+        - "Slides only (no lab run)"
+        - "Not applicable"
+    validations:
+      required: true
+  - type: dropdown
+    id: clarity
+    attributes:
+      label: Clarity
+      description: Were the instructions and explanations clear and unambiguous?
+      options:
+        - "Clear — no confusion"
+        - "Mostly clear — minor wording issues"
+        - "Confusing in places (explain below)"
+        - "Unclear — I got stuck (explain below)"
+    validations:
+      required: true
+  - type: dropdown
+    id: command-correctness
+    attributes:
+      label: Command correctness
+      description: Did the commands, manifests, and expected output work as written?
+      options:
+        - "Everything worked as written"
+        - "Worked, but expected output differed (note below)"
+        - "A command or manifest failed (details below)"
+        - "Did not run the commands"
+    validations:
+      required: true
+  - type: input
+    id: time-required
+    attributes:
+      label: Time required (minutes)
+      description: >-
+        How long did this section actually take (slides + lab)? A rough measured
+        number is fine. If you tracked slides and lab separately, note both.
+      placeholder: "e.g. slides 28, lab 34 (measured)"
+    validations:
+      required: false
+  - type: dropdown
+    id: prerequisites
+    attributes:
+      label: Prerequisite problems
+      description: Did the stated prerequisites (tools, add-ons, environment) hold?
+      options:
+        - "No problems — prerequisites held"
+        - "A prerequisite was missing or wrong (details below)"
+        - "An add-on install failed or was slow (details below)"
+        - "Not applicable"
+    validations:
+      required: true
+  - type: dropdown
+    id: learning-difficulty
+    attributes:
+      label: Learning difficulty
+      description: Was the difficulty pitched right for a beginner-to-intermediate learner?
+      options:
+        - "Well pitched"
+        - "Too easy / under-explained"
+        - "Too hard / needs more scaffolding"
+        - "Uneven (explain below)"
+    validations:
+      required: true
+  - type: dropdown
+    id: visual-quality
+    attributes:
+      label: Visual quality
+      description: Were the slides, diagrams, and comics readable and correct (no overflow, legible)?
+      options:
+        - "Good — clear and legible"
+        - "Minor issues (typos, small overflow)"
+        - "A slide/diagram was broken or unreadable (details below)"
+        - "Did not view the slides"
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: >-
+        Describe the issue. For a failed command, paste the command you ran and
+        the actual output. Note the step number where relevant.
+      placeholder: |
+        Step 3 — `kubectl get svc` returned no endpoints.
+        Ran: kubectl get endpoints web -n $NS
+        Got: <paste output>
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+      description: If you have a concrete suggestion, put it here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is about a single section/lab (or I flagged it as cross-cutting above).
+          required: true

--- a/docs/rehearsal-checklist.md
+++ b/docs/rehearsal-checklist.md
@@ -1,0 +1,135 @@
+# Rehearsal Checklist — kind path, lab by lab
+
+A pre-delivery **dry-run** checklist for the facilitator. It walks the workshop's
+**canonical `kind` path** end to end — the path where the facilitator (or a learner
+with cluster-admin) installs every add-on themselves — so the add-on installs, the
+deliberate break→fix in each lab, and the clean-state cleanup are all exercised once
+against a throwaway cluster **before** anyone is in the room.
+
+Why the `kind` path: it is the fullest path. On a shared cluster the add-ons are
+pre-installed and several labs run read-only, so a shared-cluster rehearsal never
+exercises the installs. Rehearsing on `kind` covers everything; a shared-cluster
+delivery is then a subset. See the
+[facilitator guide](./facilitator-guide.md#add-ons-what-to-pre-install-per-lab) for
+the add-on table this checklist mirrors, and the
+[syllabus](./syllabus.md#section-map-s00s27) for the canonical section map.
+
+> **Scope.** This checklist covers **every syllabus section (S00–S27)**, not just the
+> 3-day cut, because a rehearsal should exercise the whole authored superset. The
+> **Tier** column marks what is `core` / `recommended` / `optional` so you can skip
+> the cut-first sections if you are only rehearsing a specific delivery. **S24 is a
+> deferred stub** (do not rehearse as a runnable lab); **S27 is slides-only** (no lab).
+
+Two more things to keep straight before you start:
+
+> **This is a checklist, not a results log.** Record measured timings and blockers in
+> the separate [timing-results template](./timing-results-template.md) — keep measured
+> numbers out of this file. This checklist also complements the
+> [US-BETA-3 validation matrix](./validation-matrix.md) (authored in a sibling lane):
+> that matrix tracks per-lab manifest validation (client/server dry-run, live-cluster
+> confirmation); this checklist is the human walk-through of the delivery path.
+
+## How to use this checklist
+
+1. Create a fresh `kind` cluster (`kind create cluster` with the lab's
+   `kind-cluster.yaml` where a lab ships one — S08 needs the `ingress-ready` node
+   label).
+2. Work top to bottom. For each section: run the slides open in one window, do the lab
+   in another, install any add-on **before** the lab step that needs it, hit the
+   deliberate **break→fix**, then run the lab's **Cleanup / panic reset**.
+3. Tick the boxes as you go. Log the numbers in the
+   [timing-results template](./timing-results-template.md), not here.
+4. By authoring contract (see the [facilitator guide](./facilitator-guide.md)), every
+   runnable lab carries a **deliberate break→fix** (its exact shape varies — a wrong
+   value, a broken selector, a flawed manifest to audit) and ends with a **Cleanup /
+   panic reset**. Confirm both actually fire. (S24 is a stub and S27 is slides-only —
+   neither applies there.)
+
+## Pre-flight (once, before Section S00)
+
+- [ ] `kubectl` on `PATH`, within one minor version of the target API server.
+- [ ] `kind` + a container engine (Docker or Podman) installed; adequate RAM.
+- [ ] `helm` v3.8+ on `PATH` (needed for S20, S23).
+- [ ] Registry pull access from the rehearsal network (public images pull cleanly).
+- [ ] For S02: a scanner (Trivy or Grype), optionally cosign.
+- [ ] `export NS=workshop` (the kind convention) and confirm the namespace exists.
+
+## Day 1 — Foundations and the core red line
+
+| ✓ | ID | Tier | Lab | Add-on to install first | break→fix present | Cleanup runs |
+| --- | --- | --- | --- | --- | --- | --- |
+| [ ] | S00 | core | [00-setup](../labs/day-1/00-setup.md) | none | wrong context | [ ] |
+| [ ] | S01 | recommended | [01-containers](../labs/day-1/01-containers.md) | none (local, no cluster) | `latest` is not "newest" | [ ] |
+| [ ] | S02 | recommended | [02-container-security](../labs/day-1/02-container-security.md) | none (local, no cluster) | a "deleted" secret still ships | [ ] |
+| [ ] | S03 | core | [03-cluster-tour](../labs/day-1/03-cluster-tour.md) | none | a typo `explain` | [ ] |
+| [ ] | S04 | core | [04-kubectl](../labs/day-1/04-kubectl.md) | none | client says yes, server says no | [ ] |
+| [ ] | S05 | core | [05-pod](../labs/day-1/05-pod.md) | none | a bad image (ImagePullBackOff) | [ ] |
+| [ ] | S06 | core | [06-deployment](../labs/day-1/06-deployment.md) | none | a rollout that stalls | [ ] |
+| [ ] | S07 | core | [07-service](../labs/day-1/07-service.md) | none | break the selector (silent failure) | [ ] |
+| [ ] | S08 | core | [08-ingress](../labs/day-1/08-ingress.md) | **ingress-nginx** (`kind` provider manifest) | forget `pathType` | [ ] |
+
+**Day 1 add-on install to verify:** for **S08**, the `kind` cluster must carry the
+`ingress-ready` node label (from the lab's `kind-cluster.yaml`), then
+`kubectl apply -f` the ingress-nginx `kind` provider manifest and wait for the
+controller to be ready **before** the Ingress step.
+
+## Day 2 — Modern routing and running workloads well
+
+| ✓ | ID | Tier | Lab | Add-on to install first | break→fix present | Cleanup runs |
+| --- | --- | --- | --- | --- | --- | --- |
+| [ ] | S09 | recommended | [09-gateway-api](../labs/day-2/09-gateway-api.md) | **Gateway API CRDs + NGINX Gateway Fabric** | a `gatewayClassName` nobody owns | [ ] |
+| [ ] | S10 | core | [10-config](../labs/day-2/10-config.md) | none | rotate a value — env vars don't update live | [ ] |
+| [ ] | S11 | core | [11-storage](../labs/day-2/11-storage.md) | none (default StorageClass on kind) | a StorageClass that doesn't exist | [ ] |
+| [ ] | S12 | recommended | [12-statefulset](../labs/day-2/12-statefulset.md) | none (default StorageClass on kind) | a `serviceName` pointing at nothing | [ ] |
+| [ ] | S13 | core | [13-resources](../labs/day-2/13-resources.md) | none | push a container past its memory limit | [ ] |
+| [ ] | S14 | core | [14-probes](../labs/day-2/14-probes.md) | none | break readiness, then liveness | [ ] |
+| [ ] | S15 | recommended | [15-jobs](../labs/day-2/15-jobs.md) | none | a Job that fails until `backoffLimit` | [ ] |
+| [ ] | S16 | optional | [16-hpa](../labs/day-2/16-hpa.md) | **metrics-server** (kind: `--kubelet-insecure-tls`) | an HPA with nothing to divide by | [ ] |
+
+**Day 2 add-on installs to verify:** for **S09**, `kubectl apply -f` the Gateway API
+standard-channel CRDs, then the NGINX Gateway Fabric deploy manifest (provides the
+`nginx` GatewayClass), **before** the route step. For **S16**, `kubectl apply -f`
+metrics-server `components.yaml` **with the kind `--kubelet-insecure-tls` patch**, then
+confirm `kubectl top` reports before the HPA step (otherwise `TARGETS <unknown>`).
+
+## Day 3 — Security, delivery, operators, best practices
+
+| ✓ | ID | Tier | Lab | Add-on to install first | break→fix present | Cleanup runs |
+| --- | --- | --- | --- | --- | --- | --- |
+| [ ] | S17 | core | [17-pod-security](../labs/day-3/17-pod-security.md) | none (PSA built into API server) | the insecure Pod is refused at the door | [ ] |
+| [ ] | S18 | recommended | [18-networkpolicy](../labs/day-3/18-networkpolicy.md) | **policy-capable CNI** (kindnet enforces; Calico fallback) | `default-deny` fences the backend (self-test) | [ ] |
+| [ ] | S19 | optional | [19-rbac](../labs/day-3/19-rbac.md) | none | run real commands as the SA and hit the deny | [ ] |
+| [ ] | S20 | core | [20-helm](../labs/day-3/20-helm.md) | none (needs `helm` CLI) | break an upgrade, then roll back | [ ] |
+| [ ] | S21 | recommended | [21-gitops](../labs/day-3/21-gitops.md) | **Argo CD** (`install.yaml` into `argocd` ns) | drift by hand, watch self-heal revert | [ ] |
+| [ ] | S22 | recommended | [22-operator-concept](../labs/day-3/22-operator-concept.md) | **cert-manager** | delete the Secret, watch the loop remake it | [ ] |
+| [ ] | S23 | recommended | [23-prometheus](../labs/day-3/23-prometheus.md) | **kube-prometheus-stack** (Helm) | diagnose on the Prometheus `/targets` page | [ ] |
+| [ ] | S24 † | optional | [24-kubebuilder](../labs/day-3/24-kubebuilder.md) | **DEFERRED STUB — do not rehearse as a runnable lab** | n/a (unauthored) | n/a |
+| [ ] | S25 | recommended | [25-pod-escape](../labs/day-3/25-pod-escape.md) | none — **kind-only**, controlled escape; never on shared/prod | (controlled escape + hardening) | [ ] |
+| [ ] | S26 | core | [26-capstone](../labs/day-3/26-capstone.md) | none | audit a flawed manifest, then fix it | [ ] |
+| [ ] | S27 | core | *(slides only — open Q&A / office hours, no lab)* | none | n/a (no lab) | n/a |
+
+† **S24 is a deferred stub** — the slides and lab are outlined but not authored (needs a
+Go + kubebuilder toolchain). Do not schedule it as a runnable rehearsal step.
+
+**Day 3 add-on installs to verify:** **S18** — confirm your CNI actually *enforces*
+(kind's current kindnet does, via kube-network-policies; the lab's Step 2 is an
+enforcement self-test with a Calico fallback). **S21** — `kubectl create namespace
+argocd` then `kubectl apply -n argocd --server-side` the Argo CD `install.yaml`.
+**S22** — `kubectl apply -f` the cert-manager release manifest. **S23** — `helm repo
+add` prometheus-community then `helm install` kube-prometheus-stack into a `monitoring`
+namespace.
+
+## Post-rehearsal wrap-up
+
+- [ ] Every lab's **Cleanup / panic reset** left the cluster in a clean state (no
+      leftover workloads, PVCs, CRDs, or namespaces you did not expect).
+- [ ] Tear down: `kind delete cluster` and re-create from scratch confirms a clean
+      rebuild (~30 s) — the documented panic reset for the kind path.
+- [ ] All add-on installs completed within a workable time on the rehearsal network
+      (record the real durations in the
+      [timing-results template](./timing-results-template.md)).
+- [ ] Any lab where the break→fix or cleanup did **not** behave as the lab describes is
+      filed as a [beta-feedback issue](../.github/ISSUE_TEMPLATE/beta-feedback.yml).
+- [ ] Timings for every section captured in the
+      [timing-results template](./timing-results-template.md) so the planning
+      estimates can finally be checked against measured reality.

--- a/docs/timing-results-template.md
+++ b/docs/timing-results-template.md
@@ -1,0 +1,113 @@
+# Timing-Results Template — per-section MEASURED timings
+
+A blank template for recording **measured** timings during a rehearsal or beta run. Copy
+this file (e.g. to `timing-results-2026-08-15.md`), fill the **MEASURED** columns as you
+run, and keep it as the record for that run.
+
+> **Measured ≠ planned.** The `PLANNED` columns are copied from the
+> [syllabus](./syllabus.md#per-section-outcomes-timings-and-labs) — they are **unrehearsed
+> planning estimates**, not facts. The `MEASURED` columns start **empty** and hold **only
+> observed stopwatch numbers**. **Never** copy a planned value into a measured column: an
+> empty measured cell means "not yet measured", and that is the honest state until someone
+> actually times it. The whole point of this template is to replace estimates with
+> measurements — do not blur the two.
+
+## Run metadata
+
+Fill this in per run:
+
+- **Run date:** _(YYYY-MM-DD)_
+- **Facilitator / timer:** _(who kept the clock)_
+- **Environment:** _(Local kind / Shared namespace / mixed)_
+- **Cut delivered:** _(canonical 3-day cut / custom — list sections actually run)_
+- **Cluster / network notes:** _(kind version, laptop specs, network for image pulls)_
+
+## How to fill this in
+
+1. Time **slides** and **lab** separately with a stopwatch; record whole minutes in the
+   `MEASURED slides` and `MEASURED lab` columns.
+2. `Δ slides` / `Δ lab` = **measured − planned** (leave blank until you have a measured
+   value). A positive number means it ran **over** the estimate.
+3. Put anything that cost time — a slow add-on install, a broken command, a room-wide
+   stumble — in **Blockers / notes**. These are what a fix targets.
+4. Leave a cell **empty** if you did not run or did not time that section. Do **not**
+   backfill it with the planned number.
+
+## Legend
+
+- **PLANNED** — from the syllabus; an unrehearsed estimate. Do not edit these.
+- **MEASURED** — observed stopwatch minutes for this run. Empty = not measured.
+- **Δ** — measured minus planned, in minutes; blank until measured. `+` = over estimate.
+- **`—`** — not applicable (S27 has no lab; S24 is a deferred stub).
+
+## Day 1
+
+| ID | Section | PLANNED slides | PLANNED lab | MEASURED slides | MEASURED lab | Δ slides | Δ lab | Blockers / notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S00 | Welcome & setup | 20 | 15 | | | | | |
+| S01 | Containers | 30 | 25 | | | | | |
+| S02 | Container security & supply chain | 30 | 25 | | | | | |
+| S03 | Kubernetes mental model | 30 | 20 | | | | | |
+| S04 | kubectl | 25 | 25 | | | | | |
+| S05 | Pod | 30 | 25 | | | | | |
+| S06 | Deployment | 35 | 30 | | | | | |
+| S07 | Service | 30 | 30 | | | | | |
+| S08 | Ingress | 25 | 25 | | | | | |
+
+## Day 2
+
+| ID | Section | PLANNED slides | PLANNED lab | MEASURED slides | MEASURED lab | Δ slides | Δ lab | Blockers / notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S09 | Gateway API | 30 | 25 | | | | | |
+| S10 | ConfigMap & Secret | 25 | 25 | | | | | |
+| S11 | Storage (PV/PVC/StorageClass) | 30 | 30 | | | | | |
+| S12 | StatefulSet | 30 | 30 | | | | | |
+| S13 | Resources & limits | 30 | 30 | | | | | |
+| S14 | Health probes | 30 | 30 | | | | | |
+| S15 | Jobs & CronJobs | 20 | 20 | | | | | |
+| S16 | Autoscaling (HPA) | 20 | 20 | | | | | |
+
+## Day 3
+
+| ID | Section | PLANNED slides | PLANNED lab | MEASURED slides | MEASURED lab | Δ slides | Δ lab | Blockers / notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| S17 | Pod security (securityContext + PSS) | 30 | 25 | | | | | |
+| S18 | NetworkPolicy | 25 | 25 | | | | | |
+| S19 | RBAC | 25 | 25 | | | | | |
+| S20 | Helm | 30 | 30 | | | | | |
+| S21 | GitOps with Argo CD | 30 | 25 | | | | | |
+| S22 | The operator pattern | 25 | 15 | | | | | |
+| S23 | Prometheus Operator | 30 | 25 | | | | | |
+| S24 † | Operator dev 101 (kubebuilder) | 40 | 40 | | | | | Deferred stub — planned slot only, not runnable content. |
+| S25 | Security & pod escape | 35 | 30 | | | | | |
+| S26 | Best practices (capstone) | 30 | 40 | | | | | |
+| S27 | Wrap-up & next steps | 20 | — | | — | | — | Slides only — no lab. |
+
+† **S24 planned = 40/40 is a placeholder slot, not delivered content.** The lab is a
+deferred stub; do not record a measurement against it as if it were a runnable lab.
+
+## Day totals (measured vs planned)
+
+The syllabus's **planned** day totals (from the canonical 3-day cut) are the targets to
+check against. Fill the measured totals only after timing the sections you actually ran —
+sum **your MEASURED cells**, not the planned ones, and note which sections your cut
+included (the planned totals below assume the canonical cut, which omits some sections).
+
+| Day | PLANNED total (canonical cut) | MEASURED total (this run) | Δ | Sections run this run |
+| --- | --- | --- | --- | --- |
+| Day 1 | 365 | | | |
+| Day 2 | 345 | | | |
+| Day 3 | 420 | | | |
+
+> **Reading the deltas.** The open pre-delivery question is whether the cut lands near
+> **~390 min/day at ~50/50 slides:lab**. That can only be answered from the MEASURED
+> column. Until these cells are filled from a real run, the ~390 target remains an
+> **estimate**, not a measured fact — do not report it as confirmed.
+
+## Blockers summary
+
+List the cross-cutting or high-impact blockers observed this run (add-on installs that
+were slow, commands that failed, sections that consistently overran). File each as a
+[beta-feedback issue](../.github/ISSUE_TEMPLATE/beta-feedback.yml) and link it here.
+
+- _(none recorded yet — fill during the run)_


### PR DESCRIPTION
## Summary

Adds the three beta-readiness artifacts for **US-BETA-5**:

1. **`.github/ISSUE_TEMPLATE/beta-feedback.yml`** — a GitHub issue-form that renders in the chooser. Prompts for the six feedback dimensions plus section/lab and environment.
2. **`docs/rehearsal-checklist.md`** — walks the canonical **kind** path lab by lab (setup → each add-on install → each break→fix → clean-state cleanup) across all 28 syllabus sections, referencing the US-BETA-3 validation matrix.
3. **`docs/timing-results-template.md`** — a per-section MEASURED timing template with PLANNED columns from the syllabus and empty MEASURED columns, kept strictly separate.

Docs/config only — no source or build changes.

## Per-AC coverage

- **Six dimensions + section/lab + environment** — the issue form has dropdowns/inputs for clarity, command correctness, time required, prerequisite problems, learning difficulty, and visual quality, plus a **section/lab** dropdown (all S00–S27 with real lab paths, S24 marked deferred) and an **environment** dropdown ("Local kind" / "Shared namespace" — facilitator-guide terms).
- **Rehearsal checklist walks the kind path lab by lab, referencing US-BETA-3's matrix** — one row per section, add-on install column (ingress-nginx, Gateway API + NGF, metrics-server, CNI/Calico, Argo CD, cert-manager, kube-prometheus-stack), the real break→fix per lab, and cleanup; links to `docs/validation-matrix.md`.
- **Timing template: measured slide+lab minutes, deviations from planning estimate, blockers — separate from planning** — PLANNED slides/lab columns from the syllabus; empty MEASURED slides/lab + Δ columns; a blockers column and summary. Explicit "measured ≠ planned; never copy a planned value into a measured cell."
- **Negative/guardrail** — brand/AI/attribution scan is clean across all three files; the timing template never presents an estimate as a measurement (MEASURED cells start empty; S24 planned 40/40 flagged as a placeholder slot, not content).

## Honesty guardrails

- Both docs cover **every syllabus section (S00–S27)**, not just the 3-day cut — a Tier column marks core/recommended/optional. **S24** is represented as a deferred stub (not runnable); **S27** is slides-only (no lab, `—` for lab time).
- PLANNED (syllabus estimate) and MEASURED (stopwatch) are never blurred.

## Test plan / gate results

- **Issue-form YAML parses** and uses only valid field types: `python3 -c "import yaml; yaml.safe_load(...)"` → OK; field types = {markdown, input, dropdown, textarea, checkboxes}, all valid; `labels:` is a YAML array; every `markdown` item has `attributes.value` and no id/validations.
- **Every syllabus section has a row** — dry-run confirms S00–S27 each have exactly one checklist row, one timing row, and one dropdown entry (28/28).
- **`pnpm install --frozen-lockfile && pnpm lint`** → 0 errors (markdownlint scoped to `labs/**`). Both new docs also self-lint clean against strict CommonMark defaults.
- **`pnpm run build` / `build:3day` / `build:templates`** → all pass.
- `git status` shows only the 3 intended files.

## Note for reviewers

The rehearsal checklist and timing template link to **`docs/validation-matrix.md`**, which is authored in a **sibling lane (US-BETA-3)** and may not be merged yet — the plain-markdown link is intentional and is not a broken reference.