### PR TITLE
:memo: docs(beta): define beta-exit criteria (remove-the-label gate) (US-BETA-9)

### DIFF
--- a/docs/facilitator-guide.md
+++ b/docs/facilitator-guide.md
@@ -245,6 +245,52 @@ pass**. Be aware of the following, consistent with the honesty callouts already 
 - **S24 (kubebuilder) is a stub** and **S25 (pod escape) is strictly kind-only** — plan
   those two accordingly.
 
+## Beta-exit criteria — removing the beta label
+
+The workshop currently ships under a **controlled-beta** banner (see the README's
+[beta note](../README.md#kubernetes-practitioner-workshop)). This section defines when that
+banner may come off. It is the mirror image of the README banner's limitations: each
+limitation stated there is resolved by a gate below, so the two documents cannot drift —
+when every gate here is met, the banner's limitations no longer hold.
+
+> **The discipline.** Every gate below is an **objective yes/no against a named artifact**,
+> and every gate **maps to a story ID**. **No gate is "we feel ready."** Removing the beta
+> label is an evidence-based transition, not a judgement call — if you cannot point at the
+> named evidence and say "yes", the gate is unmet and the label stays.
+
+### The gates
+
+All gates must be **met** to drop the beta label. As of this writing **none is met** — the
+[validation matrix](./validation-matrix.md) is entirely `unrun` / `server-dry-run` and the
+[full rehearsal](#rehearsal-debt-read-before-you-teach) has not been run — so this is an
+unchecked list, honestly reflecting today's state.
+
+| ✓ | Gate | Story ID | Objective check (named evidence) |
+| --- | --- | --- | --- |
+| [ ] | **Full clean-environment rehearsal passed** | **US-BETA-6** | A completed copy of the [timing-results template](./timing-results-template.md) for a real run **and** maintainer sign-off that, following the [rehearsal checklist](./rehearsal-checklist.md), every canonical lab reached its expected observations and cleanup returned a clean state. US-BETA-6 is the human release gate; a passing build/dry-run is explicitly **not** sufficient. |
+| [ ] | **Validation matrix all-green** | **US-BETA-3 + US-ENV-4** | Every row in the [validation matrix](./validation-matrix.md) is at `kind-smoke` — **no** `unrun` or `server-dry-run` state remains. US-ENV-4's nightly chainsaw smoke is what moves the rows; US-BETA-3 is the tracker it fills. |
+| [ ] | **Beta feedback triaged** | **US-BETA-5** | Every issue filed via the [beta-feedback template](../.github/ISSUE_TEMPLATE/beta-feedback.yml) during the beta is **closed or explicitly accepted-deferred** — none left open and unassessed. |
+| [ ] | **S24 finished or accepted-deferred** | **US-S24** | The S24 (kubebuilder) lab is **authored** (no longer a stub) **or** there is a recorded maintainer decision to exit beta with S24 deferred. Either resolves the gate; an unaddressed stub does not. |
+| [ ] | **Repo description + discovery topics set** | **US-BETA-2** | `gh repo view --json description,repositoryTopics` returns the exact strings recorded in US-BETA-2 (a manual maintainer step). |
+
+### Promotion is gated behind the rehearsal
+
+**Broad promotion — a public Reddit post, paid or sponsored promotion, any wide launch — is
+explicitly gated behind US-BETA-6 (a successful end-to-end rehearsal).** Sharing the repo
+privately with a beta cohort is fine before then; broad promotion is not. The workshop may
+be *usable* before it is *promotable*: promotion waits on the rehearsal specifically, not on
+a general sense of polish.
+
+### If the rehearsal has not passed (blocked action)
+
+**If the US-BETA-6 clean-environment rehearsal has not passed, then a proposal to remove the
+beta label is a BLOCKED action.** Do not remove the banner, and do not begin broad
+promotion. The blocking response must **name the unmet gate** — e.g. *"Blocked: US-BETA-6
+(full clean-environment rehearsal) has not passed — the [validation matrix](./validation-matrix.md)
+still shows `unrun` rows and no completed [timing-results](./timing-results-template.md)
+exists."* Naming the specific gate is required so the block is actionable, not a vague "not
+yet".
+
 ## Quick pre-delivery checklist
 
 1. **Choose your cut** from the [3-day options](./syllabus.md#the-canonical-3-day-cut);


### PR DESCRIPTION
## Summary

Adds a **"Beta-exit criteria — removing the beta label"** section to
`docs/facilitator-guide.md` (placed after "Rehearsal debt", before the pre-delivery
checklist). It defines, as objectively checkable gates, when the workshop may drop its
controlled-beta banner. Each gate is a yes/no against a named artifact and maps to a story
ID — no gate is subjective. The section is framed as the **mirror image of the README beta
banner's limitations** (linked, not restated) so the two cannot drift.

`docs/facilitator-guide.md` was chosen over `roadmap.md` because it is tracked and already
covered by the CI link-check (`roadmap.md` is gitignored working material).

## Gate → story-ID mapping

| Gate | Story ID | Objective check (named evidence) |
| --- | --- | --- |
| Full clean-environment rehearsal passed | **US-BETA-6** | Completed `timing-results-template.md` for a real run + maintainer sign-off (via `rehearsal-checklist.md`) that every canonical lab hit expected observations and cleanup was clean. Build/dry-run explicitly not sufficient. |
| Validation matrix all-green | **US-BETA-3 + US-ENV-4** | Every `validation-matrix.md` row at `kind-smoke` — no `unrun`/`server-dry-run` left. |
| Beta feedback triaged | **US-BETA-5** | Every issue from the beta-feedback template closed or accepted-deferred. |
| S24 finished or accepted-deferred | **US-S24** | S24 lab authored (not a stub) OR a recorded maintainer decision to exit with it deferred. |
| Repo description + topics set | **US-BETA-2** | `gh repo view --json description,repositoryTopics` returns the exact US-BETA-2 strings. |

Plus: **broad Reddit / paid promotion is explicitly gated behind US-BETA-6**, and a
**BLOCKED negative case** — if the rehearsal has not passed, proposing to remove the beta
label is a blocked action that must name the unmet gate.

## AC coverage

- ✅ Concrete checkable gates, each mapping to a story ID (US-BETA-6, US-BETA-3+US-ENV-4, US-BETA-5, US-S24, US-BETA-2).
- ✅ Promotion (Reddit/paid) explicitly gated behind US-BETA-6.
- ✅ Negative case: rehearsal-not-passed makes removing the label a BLOCKED action that names the unmet gate.
- ✅ "No 'we feel ready'" discipline stated explicitly; every gate is a yes/no against a named artifact.
- ✅ Cross-references the README beta banner (`#kubernetes-practitioner-workshop`) so limitations stay in lockstep — resolution-mapped, not restated.

## Test plan

- `pnpm install --frozen-lockfile` — ok
- `pnpm lint` (labs markdownlint) — 0 errors
- `pnpm link-check` — **OK, all internal links and anchors resolve** (new links: README beta-banner anchor, `validation-matrix.md`, `rehearsal-checklist.md`, `timing-results-template.md`, `.github/ISSUE_TEMPLATE/beta-feedback.yml`, and the existing `#rehearsal-debt-read-before-you-teach` anchor)
- `pnpm run build` / `build:3day` / `build:templates` — all pass (unaffected)
- `git status` — only `docs/facilitator-guide.md`
