### PR TITLE
:memo: docs(polish): AR-15 animation-reuse guardrail reword + N1 matrix traceability (US-POLISH)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -127,8 +127,10 @@ The deck is a **superset** of toggleable sections composed by one or more **root
 - Use Shiki line highlighting (`yaml {1-3|5-8|all}`) for YAML and shell walkthroughs.
 - Use Mermaid for simple static flow/sequence diagrams only.
 - Use custom Vue + CSS components for **animated state transitions** (rolling update,
-  reconciliation, probes → endpoints, scheduling, request routing). Reuse the shared
-  animation components rather than re-implementing per slide.
+  reconciliation, probes → endpoints, scheduling, request routing). Reuse a shared
+  animation component when the state transition is the **same** as one already built.
+  When a transition is genuinely new (e.g. PVC binding ≠ StatefulSet identity ≠ admission
+  gate), author a **new self-contained component** and carry a **one-line rationale** for it.
 - Keep on-slide text concise; put facilitator detail in speaker notes.
 
 ### YAML teaching pattern

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -45,6 +45,11 @@ here is invented — every version/URL is cited from the repo as it ships today.
 > rehearsed under US-BETA-6. Everything is therefore `server-dry-run` or `unrun`, which
 > reconciles with M7.
 
+**Traceability (N1).** Every row's validation-state assignment is auditable against a
+named source: `server-dry-run` rows trace to the roadmap M4/M5 per-section progress notes
+(which record the exact cluster version each manifest was dry-run against) plus AR-05;
+`unrun` and `kind-smoke` rows trace to the honesty rule above.
+
 ## Canonical version pins (`infra/versions.env`)
 
 These are the only versions the repo pins centrally (ADR 0007). Every cluster lab runs


### PR DESCRIPTION
Docs-only lane (US-POLISH close-out). No slide/lab/behaviour change — only two tracked doc files.

## Changes

**1. AGENT.md — AR-15 accept-and-document animation-reuse guardrail.**
The blanket "reuse the shared animation components" mandate had drifted from reality: S11–S18 correctly shipped 6 justified new per-section components (PvcBinding, StatefulIdentity, ResourcePressure, HpaScaling, AdmissionGate, NetworkFence) because each depicts a genuinely different state transition. Reworded the reuse sentence so the guardrail matches accepted practice: reuse a shared component when the transition is the **same** as one already built; author a **new self-contained component** (with a **one-line rationale**) when it is genuinely new. Examples list left intact.

**2. docs/validation-matrix.md — N1 traceability line.**
Added one short sentence under the validation-state legend / honesty rule so a reader can audit any row's state claim against a named source of truth: `server-dry-run` rows trace to the roadmap M4/M5 per-section progress notes + AR-05; `unrun`/`kind-smoke` trace to the honesty rule above.

## Gate
- `pnpm install --frozen-lockfile` ✓
- `pnpm build` (superset deck) ✓
- `pnpm export` (PDF) ✓
- `markdownlint-cli2` on both files: edited regions clean, **zero new errors**. AGENT.md carries 6 pre-existing lint errors (MD031/MD040/MD051 on lines 27 and 151–166) on unrelated fenced-code content — verified pre-existing via a stash baseline diff, and left untouched per the "do not touch other AGENT.md content" constraint.