### PR TITLE
✨ feat(infra): workshop-web demo image + publish pipeline (US-ENV-8a)

### DIFF
--- a/.github/workflows/workshop-web.yml
+++ b/.github/workflows/workshop-web.yml
@@ -77,7 +77,7 @@ jobs:
             VERSION=${{ matrix.version }}
           tags: ${{ env.IMAGE }}:${{ matrix.version }}
       - name: Trivy gate (fail HIGH+)
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
           format: table

--- a/.github/workflows/workshop-web.yml
+++ b/.github/workflows/workshop-web.yml
@@ -1,0 +1,181 @@
+# workshop-web image pipeline (US-ENV-8a, lab-environment proposal §7 + §9).
+#
+# Builds the demo image that replaces the retired nginx images: multi-arch
+# (amd64+arm64), three tags (v1/v2/v3 — the rollout labs need visibly
+# different versions), Trivy-gated (fail HIGH+), cosign-signed (keyless),
+# SBOM attested, pushed to ghcr.io/platformrelay/workshop-web.
+#
+# Runs on any branch when the image source changes so the image exists as
+# soon as the US-ENV-8a lane is pushed (US-NGX consumes it before merge);
+# tags are stable (v1/v2/v3) and digest pins live in infra/versions.env.
+name: workshop-web image
+
+on:
+  push:
+    paths:
+      - infra/images/workshop-web/**
+      - .github/workflows/workshop-web.yml
+  workflow_dispatch:
+
+concurrency:
+  group: workshop-web-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/platformrelay/workshop-web
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Go vet + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra/images/workshop-web/go.mod
+      - name: gofmt (fail on diff)
+        working-directory: infra/images/workshop-web
+        run: test -z "$(gofmt -l .)"
+      - name: go vet
+        working-directory: infra/images/workshop-web
+        run: go vet ./...
+      - name: go test
+        working-directory: infra/images/workshop-web
+        run: go test ./...
+
+  build:
+    name: Build, scan, sign, push ${{ matrix.version }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to GHCR
+      id-token: write # cosign keyless signing
+    strategy:
+      matrix:
+        version: [v1, v2, v3]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push (multi-arch)
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: infra/images/workshop-web
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ matrix.version }}
+          tags: ${{ env.IMAGE }}:${{ matrix.version }}
+      - name: Trivy gate (fail HIGH+)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+          format: table
+          exit-code: "1"
+          severity: HIGH,CRITICAL
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign (keyless)
+        run: cosign sign --yes "$IMAGE@${{ steps.push.outputs.digest }}"
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+      - name: Attest SBOM
+        run: cosign attest --yes --type spdxjson --predicate sbom.spdx.json "$IMAGE@${{ steps.push.outputs.digest }}"
+      - name: Report digest
+        run: |
+          {
+            echo "### ${IMAGE}:${{ matrix.version }}"
+            echo '```'
+            echo "WORKSHOP_WEB_IMAGE_${{ matrix.version }}=${IMAGE}:${{ matrix.version }}@${{ steps.push.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  smoke:
+    # Proves the US-ENV-8a acceptance bullets on a real cluster: the image
+    # admits clean into a PSA `restricted` namespace, serves pod name +
+    # version on :8080, and POST /fail flips /ready to non-200.
+    name: kind smoke (PSA restricted)
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: workshop-web-smoke
+      - name: Create PSA-restricted namespace + pull secret
+        run: |
+          kubectl create namespace smoke
+          kubectl label namespace smoke \
+            pod-security.kubernetes.io/enforce=restricted \
+            pod-security.kubernetes.io/warn=restricted
+          kubectl -n smoke create secret docker-registry ghcr \
+            --docker-server=ghcr.io \
+            --docker-username='${{ github.actor }}' \
+            --docker-password='${{ secrets.GITHUB_TOKEN }}'
+      - name: Run workshop-web in the restricted namespace
+        run: |
+          cat <<'EOF' | kubectl apply -f -
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: web
+            namespace: smoke
+          spec:
+            imagePullSecrets:
+              - name: ghcr
+            containers:
+              - name: web
+                image: ghcr.io/platformrelay/workshop-web:v1
+                ports:
+                  - containerPort: 8080
+                readinessProbe:
+                  httpGet:
+                    path: /ready
+                    port: 8080
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  capabilities:
+                    drop: ["ALL"]
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+          EOF
+          kubectl -n smoke wait --for=condition=Ready pod/web --timeout=120s
+      - name: Verify response body and readiness toggle
+        run: |
+          kubectl -n smoke port-forward pod/web 8080:8080 &
+          sleep 3
+          body="$(curl -sf http://127.0.0.1:8080/)"
+          echo "$body"
+          echo "$body" | grep -q 'workshop-web v1'
+          echo "$body" | grep -q 'pod: web'
+          curl -sf http://127.0.0.1:8080/ready
+          curl -sf -X POST http://127.0.0.1:8080/fail
+          code="$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080/ready)"
+          test "$code" = "503"
+          curl -sf -X POST http://127.0.0.1:8080/recover
+          curl -sf http://127.0.0.1:8080/ready

--- a/.github/workflows/workshop-web.yml
+++ b/.github/workflows/workshop-web.yml
@@ -165,6 +165,12 @@ jobs:
                 type: RuntimeDefault
           EOF
           kubectl -n smoke wait --for=condition=Ready pod/web --timeout=120s
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n smoke describe pod web || true
+          kubectl -n smoke get events --sort-by=.lastTimestamp || true
+          kubectl -n smoke logs web --all-containers || true
       - name: Verify response body and readiness toggle
         run: |
           kubectl -n smoke port-forward pod/web 8080:8080 &

--- a/infra/images/workshop-web/Dockerfile
+++ b/infra/images/workshop-web/Dockerfile
@@ -19,5 +19,9 @@ ARG VERSION=dev
 ENV VERSION=${VERSION}
 COPY --from=build /workshop-web /workshop-web
 EXPOSE 8080
-USER nonroot:nonroot
+# Numeric UID:GID (the distroless nonroot user) — kubelet can only verify
+# `runAsNonRoot: true` against a NUMERIC image user; the symbolic form
+# `nonroot:nonroot` fails admission-time verification with
+# CreateContainerConfigError ("cannot verify user is non-root").
+USER 65532:65532
 ENTRYPOINT ["/workshop-web"]

--- a/infra/images/workshop-web/Dockerfile
+++ b/infra/images/workshop-web/Dockerfile
@@ -1,0 +1,23 @@
+# workshop-web — two-stage distroless build (US-ENV-8a, proposal §7).
+#
+# Result: a ~5 MB static Go binary on distroless/static, running as the
+# distroless nonroot user (65532), no shell, no package manager, no writable
+# paths needed — PSA `restricted`-clean out of the box.
+#
+# VERSION is baked per tag (v1/v2/v3) so the rollout labs get visibly
+# different versions from one Dockerfile:
+#   docker buildx build --build-arg VERSION=v2 -t ghcr.io/platformrelay/workshop-web:v2 .
+
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /workshop-web .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+ARG VERSION=dev
+ENV VERSION=${VERSION}
+COPY --from=build /workshop-web /workshop-web
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/workshop-web"]

--- a/infra/images/workshop-web/go.mod
+++ b/infra/images/workshop-web/go.mod
@@ -1,0 +1,3 @@
+module github.com/platformrelay/kubernetes-workshop/infra/images/workshop-web
+
+go 1.26

--- a/infra/images/workshop-web/main.go
+++ b/infra/images/workshop-web/main.go
@@ -1,0 +1,143 @@
+// workshop-web — the workshop's demo HTTP server (US-ENV-8a, proposal §7).
+//
+// A tiny, dependency-free replacement for the retired nginx demo images:
+// it listens on :8080 (unprivileged) and answers every request with the pod
+// name, its version (v1/v2/v3), a request counter, and its readiness state —
+// so Service load-balancing, rolling updates, and probe drains are visible
+// in the response body instead of a static welcome page.
+//
+// Endpoints:
+//
+//	GET  /         plain-text status (HTML when the client prefers text/html)
+//	GET  /healthz  liveness  — always 200 while the process runs
+//	GET  /ready    readiness — 200, or 503 after POST /fail (or FAIL_READY=1)
+//	POST /fail     flip readiness to failing (Lab 14 probe demos)
+//	POST /recover  flip readiness back to ok
+//
+// The binary never writes to disk and needs no capabilities, so it runs
+// non-root with a read-only root filesystem out of the box (PSA restricted).
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// version is set via the VERSION env var (baked per image tag: v1/v2/v3).
+var version = "dev"
+
+// versionColors makes rollouts visible at a glance in a browser.
+var versionColors = map[string]string{
+	"v1": "#326ce5", // Kubernetes blue
+	"v2": "#2ecc71", // green
+	"v3": "#e67e22", // orange
+}
+
+type server struct {
+	podName  string
+	requests atomic.Int64
+	ready    atomic.Bool
+}
+
+func newServer() *server {
+	s := &server{}
+	s.podName, _ = os.Hostname()
+	if s.podName == "" {
+		s.podName = "unknown"
+	}
+	if v := os.Getenv("VERSION"); v != "" {
+		version = v
+	}
+	// FAIL_READY=1 starts the pod not-ready (readiness-gate teaching demos).
+	s.ready.Store(os.Getenv("FAIL_READY") != "1")
+	return s
+}
+
+func (s *server) color() string {
+	if c, ok := versionColors[version]; ok {
+		return c
+	}
+	return "#95a5a6" // grey for dev/unknown versions
+}
+
+// root answers with pod name, version, request count, and readiness state.
+func (s *server) root(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	n := s.requests.Add(1)
+	ready := s.ready.Load()
+	if strings.Contains(r.Header.Get("Accept"), "text/html") {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><title>workshop-web %[1]s</title></head>
+<body style="background:%[2]s;color:#fff;font-family:monospace;padding:2rem">
+<h1>workshop-web %[1]s</h1>
+<p>pod: %[3]s</p>
+<p>requests served: %[4]d</p>
+<p>ready: %[5]t</p>
+</body></html>
+`, version, s.color(), s.podName, n, ready)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprintf(w, "workshop-web %s\npod: %s\nrequests served: %d\nready: %t\n",
+		version, s.podName, n, ready)
+}
+
+// healthz is the liveness endpoint: 200 for as long as the process serves.
+func (s *server) healthz(w http.ResponseWriter, _ *http.Request) {
+	fmt.Fprintln(w, "ok")
+}
+
+// readyz is the readiness endpoint: 200 normally, 503 after POST /fail.
+func (s *server) readyz(w http.ResponseWriter, _ *http.Request) {
+	if !s.ready.Load() {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+		return
+	}
+	fmt.Fprintln(w, "ready")
+}
+
+// setReady handles POST /fail and POST /recover.
+func (s *server) setReady(ready bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "use POST", http.StatusMethodNotAllowed)
+			return
+		}
+		s.ready.Store(ready)
+		fmt.Fprintf(w, "ready=%t\n", ready)
+	}
+}
+
+func (s *server) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.root)
+	mux.HandleFunc("/healthz", s.healthz)
+	mux.HandleFunc("/ready", s.readyz)
+	mux.HandleFunc("/fail", s.setReady(false))
+	mux.HandleFunc("/recover", s.setReady(true))
+	return mux
+}
+
+func main() {
+	s := newServer()
+	addr := ":8080"
+	if p := os.Getenv("PORT"); p != "" {
+		addr = ":" + p
+	}
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.mux(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Printf("workshop-web %s listening on %s (pod %s)", version, addr, s.podName)
+	log.Fatal(srv.ListenAndServe())
+}

--- a/infra/images/workshop-web/main_test.go
+++ b/infra/images/workshop-web/main_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testServer(t *testing.T) (*server, *httptest.Server) {
+	t.Helper()
+	s := newServer()
+	ts := httptest.NewServer(s.mux())
+	t.Cleanup(ts.Close)
+	return s, ts
+}
+
+func get(t *testing.T, url string, header ...string) (*http.Response, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i+1 < len(header); i += 2 {
+		req.Header.Set(header[i], header[i+1])
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res, string(body)
+}
+
+func post(t *testing.T, url string) *http.Response {
+	t.Helper()
+	res, err := http.Post(url, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res.Body.Close()
+	return res
+}
+
+func TestRootShowsPodVersionCountAndReadiness(t *testing.T) {
+	s, ts := testServer(t)
+	res, body := get(t, ts.URL+"/")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("GET / = %d, want 200", res.StatusCode)
+	}
+	for _, want := range []string{
+		"workshop-web " + version,
+		"pod: " + s.podName,
+		"requests served: 1",
+		"ready: true",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("GET / body missing %q:\n%s", want, body)
+		}
+	}
+	// The counter increments per request.
+	if _, body = get(t, ts.URL+"/"); !strings.Contains(body, "requests served: 2") {
+		t.Errorf("request counter did not increment:\n%s", body)
+	}
+}
+
+func TestRootServesColoredHTMLWhenAccepted(t *testing.T) {
+	_, ts := testServer(t)
+	res, body := get(t, ts.URL+"/", "Accept", "text/html")
+	if ct := res.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(body, "background:") {
+		t.Errorf("HTML body carries no version colour:\n%s", body)
+	}
+}
+
+func TestUnknownPathIs404(t *testing.T) {
+	_, ts := testServer(t)
+	if res, _ := get(t, ts.URL+"/nope"); res.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /nope = %d, want 404", res.StatusCode)
+	}
+}
+
+func TestHealthzAlwaysOK(t *testing.T) {
+	_, ts := testServer(t)
+	if res, _ := get(t, ts.URL+"/healthz"); res.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz = %d, want 200", res.StatusCode)
+	}
+	// Liveness stays green even when readiness fails.
+	post(t, ts.URL+"/fail")
+	if res, _ := get(t, ts.URL+"/healthz"); res.StatusCode != http.StatusOK {
+		t.Fatalf("GET /healthz after /fail = %d, want 200", res.StatusCode)
+	}
+}
+
+func TestFailAndRecoverFlipReadiness(t *testing.T) {
+	_, ts := testServer(t)
+	if res, _ := get(t, ts.URL+"/ready"); res.StatusCode != http.StatusOK {
+		t.Fatalf("GET /ready = %d, want 200", res.StatusCode)
+	}
+	if res := post(t, ts.URL+"/fail"); res.StatusCode != http.StatusOK {
+		t.Fatalf("POST /fail = %d, want 200", res.StatusCode)
+	}
+	if res, _ := get(t, ts.URL+"/ready"); res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /ready after /fail = %d, want 503", res.StatusCode)
+	}
+	// The root page reports the drained state.
+	if _, body := get(t, ts.URL+"/"); !strings.Contains(body, "ready: false") {
+		t.Errorf("GET / does not report ready: false:\n%s", body)
+	}
+	if res := post(t, ts.URL+"/recover"); res.StatusCode != http.StatusOK {
+		t.Fatalf("POST /recover = %d, want 200", res.StatusCode)
+	}
+	if res, _ := get(t, ts.URL+"/ready"); res.StatusCode != http.StatusOK {
+		t.Fatalf("GET /ready after /recover = %d, want 200", res.StatusCode)
+	}
+}
+
+func TestFailRequiresPOST(t *testing.T) {
+	_, ts := testServer(t)
+	if res, _ := get(t, ts.URL+"/fail"); res.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /fail = %d, want 405", res.StatusCode)
+	}
+	// A stray GET must not flip readiness.
+	if res, _ := get(t, ts.URL+"/ready"); res.StatusCode != http.StatusOK {
+		t.Fatalf("GET /ready after GET /fail = %d, want 200", res.StatusCode)
+	}
+}
+
+func TestFailReadyEnvStartsNotReady(t *testing.T) {
+	t.Setenv("FAIL_READY", "1")
+	s := newServer()
+	ts := httptest.NewServer(s.mux())
+	defer ts.Close()
+	if res, _ := get(t, ts.URL+"/ready"); res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("GET /ready with FAIL_READY=1 = %d, want 503", res.StatusCode)
+	}
+}

--- a/infra/versions.env
+++ b/infra/versions.env
@@ -42,9 +42,9 @@ WORKSHOP_SMOKE_IMAGE=registry.k8s.io/e2e-test-images/agnhost:2.66.0@sha256:e518c
 # Digests read from ghcr.io/v2/.../manifests/<tag> on 2026-07-16.
 # The deliberately broken tag `v9.99-nope` is NEVER published — it must stay
 # a registry 404 (preserves the image-pull failure demos).
-WORKSHOP_WEB_IMAGE_V1=ghcr.io/platformrelay/workshop-web:v1@sha256:c591d77b05437235ba1a74a588b0bd320a4a3608e72ad422143d81e272b759d3
-WORKSHOP_WEB_IMAGE_V2=ghcr.io/platformrelay/workshop-web:v2@sha256:770467e8896ee5466e58e5bc78d8c8c69f5635527e66d9c0a3e7e70321536cae
-WORKSHOP_WEB_IMAGE_V3=ghcr.io/platformrelay/workshop-web:v3@sha256:ae1591b91bfb0298f79dfe15589801635718ee0659714dd27d5d37f79d7ad6b2
+WORKSHOP_WEB_IMAGE_V1=ghcr.io/platformrelay/workshop-web:v1@sha256:968d2571ad2da3c205cd1fa5e1edc088c4fc779fc6d75f6a67fa012284f2fdf2
+WORKSHOP_WEB_IMAGE_V2=ghcr.io/platformrelay/workshop-web:v2@sha256:6f145da6730fbb56cb8935a32cc96903f7fbb0a2a350ad2e3a81df4c5b9de644
+WORKSHOP_WEB_IMAGE_V3=ghcr.io/platformrelay/workshop-web:v3@sha256:bae2254e7b4acb8f162ca40869a2a62927eeaa7ef20d8fdd7b96602d449d83e6
 
 # Not a version, but shared config the Makefile and doctor.sh both need.
 # Must match `name:` in infra/kind/cluster.yaml (kind configs cannot

--- a/infra/versions.env
+++ b/infra/versions.env
@@ -34,6 +34,18 @@ KUBECTL_VERSION=v1.36.1
 # header) on 2026-07-11.
 WORKSHOP_SMOKE_IMAGE=registry.k8s.io/e2e-test-images/agnhost:2.66.0@sha256:e518c9d629672720031c601b9aaa83e218ecf5821aff5cc16ac972e109096540
 
+# The workshop's demo app (US-ENV-8a, proposal §7) — replaces every retired
+# nginx demo image. Built + published by .github/workflows/workshop-web.yml
+# (multi-arch amd64+arm64, Trivy-gated, cosign-signed, SBOM attested).
+# Three tags because the rollout labs need visibly different versions.
+# Taught YAML shows the readable `:v1` form; automation consumes these pins.
+# Digests read from ghcr.io/v2/.../manifests/<tag> on 2026-07-16.
+# The deliberately broken tag `v9.99-nope` is NEVER published — it must stay
+# a registry 404 (preserves the image-pull failure demos).
+WORKSHOP_WEB_IMAGE_V1=ghcr.io/platformrelay/workshop-web:v1@sha256:c591d77b05437235ba1a74a588b0bd320a4a3608e72ad422143d81e272b759d3
+WORKSHOP_WEB_IMAGE_V2=ghcr.io/platformrelay/workshop-web:v2@sha256:770467e8896ee5466e58e5bc78d8c8c69f5635527e66d9c0a3e7e70321536cae
+WORKSHOP_WEB_IMAGE_V3=ghcr.io/platformrelay/workshop-web:v3@sha256:ae1591b91bfb0298f79dfe15589801635718ee0659714dd27d5d37f79d7ad6b2
+
 # Not a version, but shared config the Makefile and doctor.sh both need.
 # Must match `name:` in infra/kind/cluster.yaml (kind configs cannot
 # interpolate variables).


### PR DESCRIPTION
## US-ENV-8a — build & publish the `workshop-web` demo image

Prerequisite lane for **US-NGX** (P0 de-nginx): the purpose-built demo image that replaces the 120+ retired-`nginx` demo-image references across slides + labs. Design: lab-environment proposal §7.

> **Supervised lane — do NOT auto-merge.** Operator merges manually (decision D-2026-07-16-dispatch-both). The stacked US-NGX PR builds on this branch.

### What's in here

- **`infra/images/workshop-web/`** — tiny dependency-free Go HTTP server on **:8080** (unprivileged):
  - response body shows **pod name, version (v1/v2/v3), request count, readiness state** (plain text; colour-coded HTML for browsers) — Service load-balancing, rollouts, and probe drains become visible in the body
  - `GET /healthz` (liveness) · `GET /ready` (readiness) · **`POST /fail` / `POST /recover`** toggles · `FAIL_READY=1` starts not-ready — Lab 14's probe breaks no longer need file-deletion tricks
  - unit tests for every endpoint/behaviour (incl. the GET-/fail-must-not-flip guard)
- **`Dockerfile`** — two-stage build onto `distroless/static:nonroot`, **numeric `USER 65532:65532`** (kubelet can only verify `runAsNonRoot` against a numeric user — the symbolic form fails with `CreateContainerConfigError`; caught by the smoke job on the first run)
- **`.github/workflows/workshop-web.yml`** — on image-source change: gofmt/vet/test → multi-arch (amd64+arm64) build+push of `v1`/`v2`/`v3` to `ghcr.io/platformrelay/workshop-web` → **Trivy gate (fail HIGH+)** → **cosign keyless sign** → **SPDX SBOM attested** → **kind smoke job**: admits into a **PSA `restricted`** namespace, body checks, `POST /fail` flips `/ready` to 503
- **`infra/versions.env`** — `WORKSHOP_WEB_IMAGE_V1/_V2/_V3` digest pins (same KEY=value convention as `WORKSHOP_SMOKE_IMAGE`)

### Acceptance (story US-ENV-8a) — all verified

| Criterion | Evidence |
| --- | --- |
| CI builds + pushes v1/v2/v3 multi-arch on image-source change | workflow run link below; tags live on GHCR |
| Trivy gate (fail HIGH+), cosign-signed, SBOM attested | build job steps, green |
| `versions.env` carries the three digest pins | this diff |
| `curl :8080` shows pod name + version | kind smoke job assertions |
| `POST /fail` flips `/ready` non-200 | kind smoke job assertion (503) |
| non-root + read-only root FS; admits into PSA `restricted` | smoke Pod runs with full restricted securityContext |
| Broken tag stays a 404 | `v9.99-nope` never published (documented in versions.env) |
| Interim fallback documented | `registry.k8s.io/e2e-test-images/agnhost` (netexec) — not needed; the image ships with this PR |

### Notes for the operator

- The publish workflow triggers on **any branch** (paths-filtered to the image source) so the image exists for the stacked US-NGX lane pre-merge. If you'd rather restrict publishing to `main` after merge, it's a one-line `branches:` filter.
- Gateway API CRD pin nuance and controller pins land in the stacked US-NGX PR, not here.
- Digest pins match the **latest** pipeline run on this branch (each rebuild re-pushes the stable tags; pins were refreshed after the final green run).
