### PR TITLE
:memo: docs(roadmap): publish honest public direction page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ telemetry.
 | **Quizzes** | [`quiz/README.md`](./quiz/README.md) (portable prototype; FOSS live host still open) |
 | **Run slides locally** | [`docs/run-slides.md`](./docs/run-slides.md) (Node.js + pnpm) |
 | **Known limitations** | [`docs/beta-limitations.md`](./docs/beta-limitations.md) (S24 stub; add-on smoke backlog) |
+| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, GitOps choice, OpenTelemetry — no dates) |
 
 ![Animated tour of the workshop deck — real slides stepping through their click animations](docs/images/deck-showcase.gif)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,6 +42,15 @@ Pre-release tags (name contains `-`, e.g. `v0.2.0-beta.1`) set
 
 ## How to cut
 
+### Before you tag (checklist)
+
+- [ ] `main` tip is the commit you intend, and CI is green for that tip.
+- [ ] Re-verify statuses on the public [`roadmap.md`](./roadmap.md) page
+      (`in progress` / `planned` / `exploring`) against what is actually on
+      `main` — no dates, no commitment language, nothing listed as shipped that
+      is not merged. Update the page in the same release window if anything
+      drifted.
+
 ```bash
 # Confirm main is the commit you intend (and CI is green for that tip).
 git checkout main && git pull --ff-only

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,65 @@
+# Roadmap
+
+Where the workshop is heading — a **public summary** for facilitators and
+contributors. Statuses use honest vocabulary only: **in progress**, **planned**,
+or **exploring**. Nothing here is a commitment, a schedule, or a promise that
+work lands by a date. Items listed as shipped live on `main`; everything else is
+direction, not delivery.
+
+Internal planning notes (if any) stay out of the published site. This page
+summarizes; it does not lead over private trackers.
+
+## Status vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| **in progress** | Active work toward something that is not yet on `main`. |
+| **planned** | Intended next work; architecture or sequencing may still be open. |
+| **exploring** | Under consideration only — explicitly **not** committed. |
+
+## Direction
+
+### Live quizzes — planned
+
+Per-section retrieval questions plus a self-hosted live-quiz add-on for the room.
+A portable question-bank prototype already exists in
+[`quiz/`](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz).
+The architecture spike evaluated three FOSS live-host candidates and **adopted
+none of them (0/3)** — so the live host and full question bank remain **planned**,
+with architecture still open.
+
+[Discuss live quizzes →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/21)
+
+### GitOps tool choice — planned
+
+Deliver the GitOps section with **Argo CD as the default** and **Flux as a
+selectable variant**, so facilitators can match the tool their room actually
+uses without forking the curriculum.
+
+[Discuss GitOps tool choice →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/22)
+
+### OpenTelemetry — exploring
+
+Optional depth beyond the Prometheus operator path (S23): traces, OTLP, and a
+collector as a candidate add-on section. This is **exploring only** — not
+committed to the syllabus.
+
+[Discuss OpenTelemetry →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/23)
+
+## Standing debts (referenced, not restated)
+
+These are already documented on dedicated pages; the roadmap only points at them:
+
+- **Windows / WSL2 live validation** — route is contract-tested; live-smoke still
+  pending. See [Windows / WSL2](./windows-wsl2.md).
+- **Human rehearsal / beta-exit evidence** — paper and CI coverage ahead of a
+  full kind-path walk-through. See [Known limitations](./beta-limitations.md),
+  the [rehearsal checklist](./rehearsal-checklist.md), and the
+  [validation matrix](./validation-matrix.md).
+
+[Discuss standing debts →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/24)
+
+## Feedback
+
+Each item above links to a GitHub Discussion. Use those threads for interest,
+trade-offs, and evidence — not as a support queue or a delivery tracker.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Downloads & previews:
       - Live decks & PDFs: downloads.md
   - Project:
+      - Roadmap: roadmap.md
       - Release process: release.md
       - Validation matrix: validation-matrix.md
       - Rehearsal checklist: rehearsal-checklist.md

--- a/scripts/link-check.mjs
+++ b/scripts/link-check.mjs
@@ -27,6 +27,7 @@ export const DOCS = [
   'docs/syllabus.md',
   'docs/facilitator-guide.md',
   'docs/beta-limitations.md',
+  'docs/roadmap.md',
   'docs/validation-matrix.md',
   'docs/setup.md',
   'docs/windows-wsl2.md',

--- a/scripts/pages-site.test.mjs
+++ b/scripts/pages-site.test.mjs
@@ -32,3 +32,7 @@ test('docs landing and run-slides exist', () => {
   assert.ok(existsSync(resolve(ROOT, 'docs/run-slides.md')))
   assert.ok(existsSync(resolve(ROOT, 'docs/downloads.md')))
 })
+
+test('public roadmap page exists for MkDocs', () => {
+  assert.ok(existsSync(resolve(ROOT, 'docs/roadmap.md')))
+})

--- a/scripts/readme-front-door.test.mjs
+++ b/scripts/readme-front-door.test.mjs
@@ -54,3 +54,31 @@ test('README describes 0BSD without MIT attribution requirement', () => {
   assert.doesNotMatch(readme, /Keep the copyright notice with substantial copies/)
   assert.doesNotMatch(readme, /\[MIT License\]|\*\*\[MIT\]|License: MIT/)
 })
+
+test('README links the public roadmap page', () => {
+  const readme = readFileSync(resolve(ROOT, 'README.md'), 'utf8')
+  assert.match(
+    readme,
+    /\[`?docs\/roadmap\.md`?\]\(\.\/docs\/roadmap\.md\)|\[([^\]]*roadmap[^\]]*)\]\(\.\/docs\/roadmap\.md\)/i,
+    'README must link docs/roadmap.md',
+  )
+})
+
+test('mkdocs nav includes the public roadmap page', () => {
+  const yml = readFileSync(resolve(ROOT, 'mkdocs.yml'), 'utf8')
+  assert.match(yml, /roadmap\.md/, 'mkdocs.yml nav must include roadmap.md')
+})
+
+test('release checklist re-verifies roadmap statuses at every tag', () => {
+  const release = readFileSync(resolve(ROOT, 'docs/release.md'), 'utf8')
+  assert.match(
+    release,
+    /roadmap/i,
+    'docs/release.md must mention the public roadmap',
+  )
+  assert.match(
+    release,
+    /re-verif/i,
+    'docs/release.md must require re-verifying roadmap statuses at tag time',
+  )
+})


### PR DESCRIPTION
## Summary
- Adds public `docs/roadmap.md` with honest statuses (`planned` / `exploring`) for live quizzes (0/3 FOSS — architecture open), GitOps tool choice (Argo CD default / Flux variant), and OpenTelemetry (exploring, not committed).
- Wires the page into MkDocs nav under Project, links it from the README front-door table, and adds a release-checklist drift guard so statuses are re-verified at every tag.
- Each roadmap item links to a real GitHub Discussion (#21–#24); standing debts are referenced, not duplicated.

## Test plan
- [x] `node --test scripts/readme-front-door.test.mjs scripts/pages-site.test.mjs` (includes new roadmap contracts)
- [x] `pnpm link-check` (DOCS list includes `docs/roadmap.md`)
- [x] `mkdocs build --strict` green; `/roadmap/` present in site sitemap