### PR TITLE
:sparkles: feat(deck): S21 GitOps variant switch (US-GITOPS-CHOICE-A)

### DIFF
--- a/docs/run-slides.md
+++ b/docs/run-slides.md
@@ -48,6 +48,28 @@ pnpm dev:optional    # Optional / Appendix
 pnpm dev:templates   # Theme / template gallery
 ```
 
+### Facilitator launcher and S21 GitOps tool
+
+For a one-off facilitator selection (day, section, or range), use `pnpm deck` with an
+explicit selector. Non-interactive shells must pass the selector on the command line;
+the gum menu is progressive enhancement when a TTY and gum are available.
+
+S21 ships as a two-way switch — **Argo CD** (default) or **Flux**. Exactly one tool per
+delivery; there is no "both" mode and no third-tool plug-in surface.
+
+```bash
+# Default GitOps tool is Argo CD (byte-identical to the committed day decks)
+pnpm deck -- --day 3 --dry-run
+
+# Select the Flux variant for S21 (requires pages/S21-gitops-flux/ — US-GITOPS-CHOICE-B)
+pnpm deck -- --day 3 --gitops flux --dry-run
+
+# Regenerate / check committed decks for a chosen tool (default: argocd)
+pnpm decks:generate
+pnpm decks:check
+pnpm decks:generate -- --gitops flux   # fails clearly until the Flux section exists
+```
+
 Slidev prints a local URL — typically:
 
 ```text

--- a/scripts/deck-manifest.mjs
+++ b/scripts/deck-manifest.mjs
@@ -56,6 +56,56 @@ export const generatedDecks = [
   { file: 'slides.md', title: 'Content superset', description: 'Compatibility deck containing every section source', select: () => true },
 ]
 
+/** S21 GitOps tool switch — Argo CD | Flux only (US-GITOPS-CHOICE). Not a plugin API. */
+export const GITOPS_TOOLS = Object.freeze(['argocd', 'flux'])
+export const DEFAULT_GITOPS = 'argocd'
+
+const S21_GITOPS_VARIANTS = Object.freeze({
+  argocd: { slug: 'gitops', title: 'GitOps with Argo CD' },
+  flux: { slug: 'gitops-flux', title: 'GitOps with Flux' },
+})
+
+const S21_GITOPS_SRC = Object.freeze({
+  argocd: './pages/S21-gitops/index.md',
+  flux: './pages/S21-gitops-flux/index.md',
+})
+
+export function normalizeGitops(value = DEFAULT_GITOPS) {
+  if (value === undefined || value === null)
+    return DEFAULT_GITOPS
+  if (typeof value !== 'string' || !value.trim())
+    throw new Error('GitOps tool required; use exactly one of: argocd, flux')
+  const tool = value.trim().toLowerCase()
+  if (tool === 'both' || tool.includes(','))
+    throw new Error('Choose exactly one GitOps tool (argocd or flux); both is not allowed')
+  if (!GITOPS_TOOLS.includes(tool))
+    throw new Error(`Unknown GitOps tool ${value}; use exactly one of: argocd, flux`)
+  return tool
+}
+
+export function applyGitopsVariant(manifest = sections, gitops = DEFAULT_GITOPS) {
+  const tool = normalizeGitops(gitops)
+  const variant = S21_GITOPS_VARIANTS[tool]
+  return manifest.map((section) => {
+    if (section.id !== 'S21')
+      return section
+    return { ...section, slug: variant.slug, title: variant.title, gitops: tool }
+  })
+}
+
+export function assertExactlyOneGitopsVariant(markdown) {
+  const hasArgocd = markdown.includes(`src: ${S21_GITOPS_SRC.argocd}`)
+  const hasFlux = markdown.includes(`src: ${S21_GITOPS_SRC.flux}`)
+  const claimsS21 = /(?:^|\n)#\s*S21\b/.test(markdown) || hasArgocd || hasFlux
+  if (!claimsS21)
+    return true
+  if (hasArgocd && hasFlux)
+    throw new Error('Deck includes both GitOps variants; choose exactly one (argocd or flux)')
+  if (!hasArgocd && !hasFlux)
+    throw new Error('Deck claims S21 but includes neither GitOps variant source')
+  return true
+}
+
 export function sectionPath(section) {
   return `./pages/${section.id}-${section.slug}/index.md`
 }
@@ -518,11 +568,13 @@ export function renderDeck(selected, { title, description, generated = true } = 
   return `---\ntheme: ./theme\ntitle: Kubernetes Practitioner Workshop — ${title}\ninfo: |\n  Open source, vendor-neutral Kubernetes workshop.\n  ${description}. Sections are imported from the shared section library.\nlayout: cover\n---\n${marker}\n# Kubernetes Practitioner Workshop\n\n${title} — ${description}.\n${statusNotice}\n${imports}\n`
 }
 
-export function renderGeneratedDecks(manifest = sections) {
-  return new Map(generatedDecks.map((deck) => [
-    deck.file,
-    renderDeck(manifest.filter(deck.select), deck),
-  ]))
+export function renderGeneratedDecks(manifest = sections, { gitops = DEFAULT_GITOPS } = {}) {
+  const resolved = applyGitopsVariant(manifest, gitops)
+  return new Map(generatedDecks.map((deck) => {
+    const content = renderDeck(resolved.filter(deck.select), deck)
+    assertExactlyOneGitopsVariant(content)
+    return [deck.file, content]
+  }))
 }
 
 export function findGeneratedDrift(expected, { repoRoot = resolve(import.meta.dirname, '..') } = {}) {

--- a/scripts/deck-selector.mjs
+++ b/scripts/deck-selector.mjs
@@ -1,3 +1,5 @@
+import { DEFAULT_GITOPS, GITOPS_TOOLS, normalizeGitops } from './deck-manifest.mjs'
+
 const DAY_VALUES = new Set(['1', '2', '3', 'optional'])
 
 export function parseSelection(args) {
@@ -6,6 +8,8 @@ export function parseSelection(args) {
   let list = false
   let dryRun = false
   let help = false
+  let gitops
+  let gitopsSet = false
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i]
@@ -19,6 +23,14 @@ export function parseSelection(args) {
       selection = setOnce(selection, { type: 'section', value: normalizeId(args[++i]) })
     } else if (arg === '--range') {
       selection = setOnce(selection, { type: 'range', value: args[++i] ?? '' })
+    } else if (arg === '--gitops') {
+      if (gitopsSet)
+        throw new Error('Pass --gitops at most once; choose exactly one of: argocd, flux')
+      gitopsSet = true
+      const value = args[++i]
+      if (value === undefined || value.startsWith('--'))
+        throw new Error('Missing --gitops value; use exactly one of: argocd, flux')
+      gitops = normalizeGitops(value)
     } else if (arg === '--action') {
       action = args[++i]
       if (!['dev', 'build', 'export'].includes(action))
@@ -28,17 +40,34 @@ export function parseSelection(args) {
     else if (arg === '--help' || arg === '-h') help = true
     else throw new Error(`Unknown option ${arg}`)
   }
-  return { ...selection, action, list, dryRun, help }
+  return {
+    ...selection,
+    action,
+    list,
+    dryRun,
+    help,
+    gitops: gitopsSet ? gitops : DEFAULT_GITOPS,
+    gitopsExplicit: gitopsSet,
+  }
 }
 
 export function resolveSelection(args, { isTTY = Boolean(process.stdin.isTTY), hasGum = false } = {}) {
   const parsed = parseSelection(args)
   if (parsed.list || parsed.help || parsed.type)
     return parsed
-  if (isTTY && hasGum)
-    return { type: 'interactive', action: parsed.action, dryRun: parsed.dryRun }
+  if (isTTY && hasGum) {
+    return {
+      type: 'interactive',
+      action: parsed.action,
+      dryRun: parsed.dryRun,
+      gitops: parsed.gitops,
+      gitopsExplicit: parsed.gitopsExplicit,
+    }
+  }
   throw new Error('Choose a deck with --day, --section, or --range (use --list to inspect choices).')
 }
+
+export { DEFAULT_GITOPS, GITOPS_TOOLS }
 
 export function selectSections(sections, selection) {
   if (selection.type === 'day') {

--- a/scripts/deck.mjs
+++ b/scripts/deck.mjs
@@ -2,7 +2,13 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { renderDeck, sections, validateManifest } from './deck-manifest.mjs'
+import {
+  DEFAULT_GITOPS,
+  applyGitopsVariant,
+  renderDeck,
+  sections,
+  validateManifest,
+} from './deck-manifest.mjs'
 import { resolveSelection, selectSections } from './deck-selector.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
@@ -17,10 +23,15 @@ function usage() {
 
 Usage:
   pnpm deck -- --day 1 [--action dev|build|export]
+  pnpm deck -- --day 3 [--gitops argocd|flux]
   pnpm deck -- --day optional
   pnpm deck -- --section S05
   pnpm deck -- --range S05-S09
   pnpm deck -- --list
+
+--gitops selects the S21 GitOps tool (argocd default, or flux). Exactly one tool per
+delivery; there is no "both" mode. Without an interactive terminal, pass --gitops
+explicitly when you want flux (default remains argocd).
 
 With an interactive terminal and gum installed, running without a selector opens a menu.
 Without gum or a TTY, pass an explicit selector; the content superset is never selected by default.
@@ -50,15 +61,30 @@ function gumChoose() {
     : { type: 'range', value: input.stdout.trim() }
 }
 
-function printSections() {
-  for (const section of sections) {
+function gumChooseGitops() {
+  const choice = spawnSync('gum', [
+    'choose',
+    'Argo CD (default)',
+    'Flux',
+    '--header', 'S21 GitOps tool (exactly one)',
+  ], { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] })
+  if (choice.status !== 0)
+    throw new Error('Deck selection cancelled')
+  return choice.stdout.trim().startsWith('Flux') ? 'flux' : 'argocd'
+}
+
+function selectionIncludesS21(selected) {
+  return selected.some((section) => section.id === 'S21')
+}
+
+function printSections(resolvedSections) {
+  for (const section of resolvedSections) {
     const cut = section.canonical ? `Day ${section.day}` : 'Optional / Appendix'
     console.log(`${section.id}  ${cut.padEnd(19)} ${section.title}`)
   }
 }
 
 try {
-  validateManifest(sections, { repoRoot })
   let selection = resolveSelection(process.argv.slice(2), {
     isTTY: Boolean(process.stdin.isTTY && process.stdout.isTTY),
     hasGum: commandExists('gum'),
@@ -67,14 +93,32 @@ try {
     console.log(usage())
     process.exit(0)
   }
+
+  let gitops = selection.gitops ?? DEFAULT_GITOPS
+  let resolvedSections = applyGitopsVariant(sections, gitops)
+  validateManifest(resolvedSections, { repoRoot })
+
   if (selection.list) {
-    printSections()
+    printSections(resolvedSections)
     process.exit(0)
   }
   if (selection.type === 'interactive')
     selection = { ...selection, ...gumChoose() }
 
-  const selected = selectSections(sections, selection)
+  let selected = selectSections(resolvedSections, selection)
+  if (
+    selectionIncludesS21(selected)
+    && !selection.gitopsExplicit
+    && selection.type !== undefined
+    && Boolean(process.stdin.isTTY && process.stdout.isTTY)
+    && commandExists('gum')
+  ) {
+    gitops = gumChooseGitops()
+    resolvedSections = applyGitopsVariant(sections, gitops)
+    validateManifest(resolvedSections, { repoRoot })
+    selected = selectSections(resolvedSections, selection)
+  }
+
   const label = selection.type === 'day'
     ? (selection.value === 'optional' ? 'Optional / Appendix' : `Day ${selection.value}`)
     : selected.length === 1 ? `${selected[0].id} · ${selected[0].title}` : `${selected[0].id}–${selected.at(-1).id}`
@@ -83,7 +127,8 @@ try {
     description: 'facilitator selection',
     generated: false,
   }))
-  console.log(`${label}: ${selected.map((section) => section.id).join(', ')}`)
+  const gitopsNote = selectionIncludesS21(selected) ? ` [gitops=${gitops}]` : ''
+  console.log(`${label}: ${selected.map((section) => section.id).join(', ')}${gitopsNote}`)
   if (selection.dryRun)
     process.exit(0)
 

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -5,9 +5,15 @@ import { join } from 'node:path'
 import { describe, it } from 'node:test'
 
 import {
+  DEFAULT_GITOPS,
+  applyGitopsVariant,
+  assertExactlyOneGitopsVariant,
   canonicalDayTotals,
   findGeneratedDrift,
+  normalizeGitops,
   renderDeck,
+  renderGeneratedDecks,
+  sectionPath,
   sections as workshopSections,
   validateCanonicalScheduleTables,
   validateFrontDoorFacts,
@@ -495,7 +501,41 @@ describe('deck selection', () => {
   it('accepts pnpm argument separators without changing the selection', () => {
     assert.deepEqual(
       parseSelection(['--', '--day', '2']),
-      { type: 'day', value: '2', action: 'dev', list: false, dryRun: false, help: false },
+      {
+        type: 'day',
+        value: '2',
+        action: 'dev',
+        list: false,
+        dryRun: false,
+        help: false,
+        gitops: DEFAULT_GITOPS,
+        gitopsExplicit: false,
+      },
+    )
+  })
+
+  it('accepts an explicit --gitops flux flag alongside --day', () => {
+    assert.deepEqual(
+      parseSelection(['--day', '3', '--gitops', 'flux']),
+      {
+        type: 'day',
+        value: '3',
+        action: 'dev',
+        list: false,
+        dryRun: false,
+        help: false,
+        gitops: 'flux',
+        gitopsExplicit: true,
+      },
+    )
+  })
+
+  it('rejects unknown or duplicate --gitops values', () => {
+    assert.throws(() => parseSelection(['--day', '3', '--gitops', 'both']), /gitops/i)
+    assert.throws(() => parseSelection(['--day', '3', '--gitops']), /gitops/i)
+    assert.throws(
+      () => parseSelection(['--day', '3', '--gitops', 'argocd', '--gitops', 'flux']),
+      /gitops/i,
     )
   })
 
@@ -535,5 +575,99 @@ describe('deck CI contract', () => {
     ]) {
       assert.match(workflow, new RegExp(`^\\s*${command}$`, 'm'))
     }
+  })
+})
+
+describe('S21 GitOps section variant (US-GITOPS-CHOICE-A)', () => {
+  it('defaults to argocd and keeps the existing S21 source path', () => {
+    assert.equal(normalizeGitops(), 'argocd')
+    assert.equal(normalizeGitops(undefined), 'argocd')
+    assert.equal(DEFAULT_GITOPS, 'argocd')
+
+    const resolved = applyGitopsVariant(workshopSections)
+    const s21 = resolved.find((section) => section.id === 'S21')
+    assert.equal(s21.slug, 'gitops')
+    assert.equal(s21.title, 'GitOps with Argo CD')
+    assert.equal(sectionPath(s21), './pages/S21-gitops/index.md')
+  })
+
+  it('keeps default regenerated decks byte-identical to the committed files', () => {
+    const expected = renderGeneratedDecks(workshopSections)
+    const root = join(import.meta.dirname, '..')
+    for (const [file, content] of expected) {
+      assert.equal(
+        readFileSync(join(root, file), 'utf8'),
+        content,
+        `${file} drifted from default (argocd) render`,
+      )
+    }
+    assert.deepEqual(findGeneratedDrift(expected, { repoRoot: root }), [])
+  })
+
+  it('selects the flux variant path when gitops=flux', () => {
+    const resolved = applyGitopsVariant(workshopSections, 'flux')
+    const s21 = resolved.find((section) => section.id === 'S21')
+    assert.equal(s21.slug, 'gitops-flux')
+    assert.equal(s21.title, 'GitOps with Flux')
+    assert.equal(sectionPath(s21), './pages/S21-gitops-flux/index.md')
+
+    const day3 = renderGeneratedDecks(workshopSections, { gitops: 'flux' }).get('slides-day-3.md')
+    assert.match(day3, /src: \.\/pages\/S21-gitops-flux\/index\.md/)
+    assert.doesNotMatch(day3, /src: \.\/pages\/S21-gitops\/index\.md/)
+  })
+
+  it('rejects both or neither GitOps variants in a deck that includes S21', () => {
+    const both = `
+# S21 · GitOps with Argo CD · recommended · Day 3 · authored
+src: ./pages/S21-gitops/index.md
+---
+# S21 · GitOps with Flux · recommended · Day 3 · authored
+src: ./pages/S21-gitops-flux/index.md
+`
+    assert.throws(() => assertExactlyOneGitopsVariant(both), /both.*gitops|gitops.*both/i)
+
+    const neither = `
+# S21 · GitOps · recommended · Day 3 · authored
+src: ./pages/S21-missing/index.md
+`
+    assert.throws(() => assertExactlyOneGitopsVariant(neither), /neither.*gitops|gitops.*neither/i)
+
+    const argocdOnly = `
+# S21 · GitOps with Argo CD · recommended · Day 3 · authored
+src: ./pages/S21-gitops/index.md
+`
+    assert.equal(assertExactlyOneGitopsVariant(argocdOnly), true)
+
+    const noS21 = `
+# S05 · Pod · core · Day 1 · authored
+src: ./pages/S05-pod/index.md
+`
+    assert.equal(assertExactlyOneGitopsVariant(noS21), true)
+  })
+
+  it('rejects invalid gitops tool values (two tools only)', () => {
+    assert.throws(() => normalizeGitops('both'), /argocd|flux/i)
+    assert.throws(() => normalizeGitops(''), /argocd|flux/i)
+    assert.throws(() => normalizeGitops('tekton'), /argocd|flux/i)
+  })
+
+  it('fails clearly when the flux variant source is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'workshop-gitops-'))
+    mkdirSync(join(root, 'pages', 'S21-gitops'), { recursive: true })
+    writeFileSync(join(root, 'pages', 'S21-gitops', 'index.md'), '# argocd\n')
+
+    const fluxManifest = applyGitopsVariant([
+      section('S21', {
+        slug: 'gitops',
+        title: 'GitOps with Argo CD',
+        day: 3,
+        tier: 'recommended',
+      }),
+    ], 'flux')
+
+    assert.throws(
+      () => validateManifest(fluxManifest, { repoRoot: root }),
+      /S21-gitops-flux|flux variant|missing section source.*S21/i,
+    )
   })
 })

--- a/scripts/generate-decks.mjs
+++ b/scripts/generate-decks.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
+  DEFAULT_GITOPS,
+  applyGitopsVariant,
+  assertExactlyOneGitopsVariant,
   findGeneratedDrift,
+  normalizeGitops,
   renderGeneratedDecks,
   sections,
   validateDocumentationTruth,
@@ -12,19 +16,51 @@ import {
 const repoRoot = resolve(import.meta.dirname, '..')
 const check = process.argv.includes('--check')
 
-validateManifest(sections, { repoRoot })
-validateDocumentationTruth(sections, { repoRoot })
-const expected = renderGeneratedDecks(sections)
+function parseGitops(argv) {
+  const index = argv.indexOf('--gitops')
+  if (index < 0)
+    return DEFAULT_GITOPS
+  return normalizeGitops(argv[index + 1])
+}
+
+const gitops = parseGitops(process.argv.slice(2))
+const resolved = applyGitopsVariant(sections, gitops)
+
+try {
+  validateManifest(resolved, { repoRoot })
+} catch (error) {
+  if (gitops === 'flux' && /S21-gitops-flux/.test(error.message)) {
+    console.error(
+      `decks: flux variant selected but ${error.message}. `
+        + 'Flux section content is not authored yet; use --gitops argocd (default) until it lands.',
+    )
+    process.exit(1)
+  }
+  throw error
+}
+validateDocumentationTruth(resolved, { repoRoot })
+const expected = renderGeneratedDecks(sections, { gitops })
 const drift = findGeneratedDrift(expected, { repoRoot })
 
+for (const [file, content] of expected)
+  assertExactlyOneGitopsVariant(content)
+
 if (check) {
+  for (const file of expected.keys()) {
+    const onDisk = readFileSync(resolve(repoRoot, file), 'utf8')
+    assertExactlyOneGitopsVariant(onDisk)
+  }
   if (drift.length) {
     console.error(`Generated deck drift: ${drift.join(', ')}. Run \`pnpm decks:generate\`.`)
     process.exit(1)
   }
-  console.log(`Generated decks are current (${expected.size} entries, ${sections.length} sections).`)
+  console.log(
+    `Generated decks are current (${expected.size} entries, ${resolved.length} sections, gitops=${gitops}).`,
+  )
 } else {
   for (const [file, content] of expected)
     writeFileSync(resolve(repoRoot, file), content)
-  console.log(`Generated ${expected.size} deck entries from ${sections.length} sections.`)
+  console.log(
+    `Generated ${expected.size} deck entries from ${resolved.length} sections (gitops=${gitops}).`,
+  )
 }

--- a/scripts/lab-inventory.mjs
+++ b/scripts/lab-inventory.mjs
@@ -205,6 +205,26 @@ export function selectLabs(inventory, selection) {
   }
 }
 
+/**
+ * Delivery-facing inventory: keep exactly one S21 GitOps lab variant.
+ * Argo CD → labs/day-3/21-gitops.md; Flux → labs/day-3/21-gitops-flux.md (slice C).
+ */
+export function mapDeliveryLabs(labs, { gitops = 'argocd' } = {}) {
+  const tool = String(gitops ?? 'argocd').trim().toLowerCase();
+  if (tool !== 'argocd' && tool !== 'flux') {
+    throw new Error(`Unknown GitOps tool ${gitops}; use exactly one of: argocd, flux`);
+  }
+  return labs.filter((lab) => {
+    const path = lab.labPath ?? '';
+    const isGitopsLab = /\/21-gitops(?:-flux)?\.md$/.test(path);
+    if (!isGitopsLab)
+      return true;
+    if (tool === 'flux')
+      return path.endsWith('/21-gitops-flux.md');
+    return path.endsWith('/21-gitops.md');
+  });
+}
+
 export function main(argv = process.argv.slice(2)) {
   const write = argv.includes('--write');
   const check = argv.includes('--check');

--- a/scripts/lab-inventory.test.mjs
+++ b/scripts/lab-inventory.test.mjs
@@ -10,6 +10,7 @@ import {
   INVENTORY_PATH,
   buildInventory,
   classifyAutomationTier,
+  mapDeliveryLabs,
   parseMatrixRows,
   renderInventory,
   selectLabs,
@@ -224,6 +225,24 @@ test('selectLabs filters pr-day1 and schedule shards', () => {
     day2.map((lab) => lab.id),
     ['day-2/09-gateway-api'],
   );
+});
+
+test('mapDeliveryLabs keeps exactly one S21 GitOps lab variant', () => {
+  const labs = [
+    { labPath: 'labs/day-3/20-helm.md', section: 'S20' },
+    { labPath: 'labs/day-3/21-gitops.md', section: 'S21' },
+    { labPath: 'labs/day-3/21-gitops-flux.md', section: 'S21' },
+    { labPath: 'labs/day-3/22-operator-concept.md', section: 'S22' },
+  ];
+  assert.deepEqual(
+    mapDeliveryLabs(labs).map((lab) => lab.labPath),
+    ['labs/day-3/20-helm.md', 'labs/day-3/21-gitops.md', 'labs/day-3/22-operator-concept.md'],
+  );
+  assert.deepEqual(
+    mapDeliveryLabs(labs, { gitops: 'flux' }).map((lab) => lab.labPath),
+    ['labs/day-3/20-helm.md', 'labs/day-3/21-gitops-flux.md', 'labs/day-3/22-operator-concept.md'],
+  );
+  assert.throws(() => mapDeliveryLabs(labs, { gitops: 'both' }), /argocd|flux/i);
 });
 
 test('renderInventory is stable JSON and real repo inventory covers all matrix labs', () => {


### PR DESCRIPTION
## Summary
- Adds an S21 section-variant switch (`argocd` default | `flux`) in `scripts/deck-manifest.mjs`: generated day decks include exactly one variant; `pnpm decks:check` / `assertExactlyOneGitopsVariant` fail on both-or-neither.
- Launcher flag: `--gitops argocd|flux` (e.g. `pnpm deck -- --day 3 --gitops flux`). Default omitted keeps Argo CD; gum may offer the same two choices when TTY+gum and S21 is in the selection; non-TTY flux selection requires the explicit flag.
- Flux path (`pages/S21-gitops-flux/`) is selectable in the API but generation fails clearly until US-GITOPS-CHOICE-B authors it. No Flux curriculum content in this PR.
- Minimal delivery hook: `mapDeliveryLabs(..., { gitops })` keeps exactly one S21 lab path for later C wiring.
- Docs: `docs/run-slides.md` (not README — parallel lane). Decision log: `--gitops` spelling in `agent-context/decisions.md` (`D-2026-08-06-gitops-flag-spelling`).

## Invariants
- Exactly one GitOps tool per delivery; two tools only (no third-tool plugin API).
- Default (no flag) regenerated decks are **byte-identical** to pre-lane output (sha verified).
- S21 timings unchanged (30/25).

## Test plan
- [x] `pnpm test:deck` (includes new variant contract tests)
- [x] `node --test scripts/lab-inventory.test.mjs` (mapDeliveryLabs)
- [x] `pnpm decks:check` (gitops=argocd)
- [x] `node scripts/generate-decks.mjs --gitops flux` exits 1 with clear missing-source message
- [x] Fixture: both-or-neither `assertExactlyOneGitopsVariant` red
- [ ] CI on this PR