### PR TITLE
:memo: docs(flux): honest smoke-receipt span + flux-correct solution states

### DIFF
--- a/docs/validation-evidence/us-gitops-choice-c-flux-live-smoke.md
+++ b/docs/validation-evidence/us-gitops-choice-c-flux-live-smoke.md
@@ -1,6 +1,9 @@
 # US-GITOPS-CHOICE-C Flux lab live kind smoke receipt
 
-- **When (UTC):** 2026-08-05T23:14:40Z → 2026-08-05T23:16:10Z (successful end-to-end pass)
+- **When (UTC):** 2026-08-05 (successful end-to-end pass). Two clock marks were
+  recorded during the pass — `2026-08-05T23:14:40Z` and `2026-08-05T23:16:10Z` —
+  but they do **not** bound the full install-to-cleanup run (see
+  [Honesty](#honesty))
 - **Host:** macOS + Colima (Docker 29.x; `kind` + `kubectl` local)
 - **Architecture:** `aarch64` (Apple Virtualization.Framework)
 - **Lab:** [`labs/day-3/21-gitops-flux.md`](../../labs/day-3/21-gitops-flux.md)
@@ -29,3 +32,12 @@
 Maintainer-recorded disposable-cluster run for the Flux lab variant. Promotes the
 `day-3/21-gitops-flux.md` matrix row to `kind-smoke`. Does **not** claim pedagogical
 room timing (US-BETA-6). Sibling Argo CD lab row remains unchanged.
+
+**Timing scope:** this receipt evidences beat *ordering and outcomes*, not total
+duration. Per-beat wall-clock timestamps were not captured; the approximate
+durations in the beat table are the only per-beat timing recorded. The two clock
+marks above span ~90 seconds, which cannot contain the whole run — the Flux
+install + controller wait plus the beat-table observe windows alone exceed it —
+so read them as marks recorded during the pass, not as run start/end bounds. An
+earlier revision of this receipt presented them as the full run window; that
+claim is retracted.

--- a/labs/day-3/21-gitops-flux.solution.md
+++ b/labs/day-3/21-gitops-flux.solution.md
@@ -347,9 +347,10 @@ the GitRepository.
 - **Suspend ⇒ drift stays.** With `spec.suspend: true`, the same drift is *not* reverted —
   the Argo `selfHeal: false` analog.
 
-Representative statuses include Ready/Running Pods, NetworkPolicy timeouts, RBAC Forbidden,
-Helm revision history, Flux Ready conditions, Certificate Ready, or Prometheus targets —
-compare meaning, not ephemeral names.
+Representative statuses include Ready/Running Pods, GitRepository and Kustomization
+`Ready=True/False` conditions, kstatus-style `Reconciling` progress, stored-artifact and
+Applied-revision messages, and the Kustomization's `spec.suspend` flag — compare meaning,
+not ephemeral values (revision SHAs, Pod-name suffixes, ages).
 
 ## Explanation
 


### PR DESCRIPTION
Closes out two docs-honesty findings from the independent review of PR #28 (US-GITOPS-CHOICE-C, Flux lab).

## C-F1 (P2) — receipt wall-clock could not be true as stated
`docs/validation-evidence/us-gitops-choice-c-flux-live-smoke.md` claimed a ~90-second run window (23:14:40Z → 23:16:10Z) that cannot contain the Flux install + controller wait plus the listed post-install beats (whose observe-window floors alone sum to ~85s).

Fix (no new timestamps or durations invented): the two clock marks are kept as recorded facts but explicitly no longer presented as run start/end bounds. A new **Timing scope** paragraph in the Honesty section states that the receipt evidences beat ordering and outcomes, that per-beat wall-clock timestamps were not captured, and that the earlier full-run-window claim is retracted. All genuine corroborators (Flux v2.9.3, install SHA-pinned revision, kindest/node v1.36.1, beat outcomes) are unchanged.

## C-F3 (P3) — solution boilerplate listed non-Flux statuses
`labs/day-3/21-gitops-flux.solution.md` Expected-state boilerplate still listed statuses from other labs / the Argo sibling (NetworkPolicy timeouts, RBAC Forbidden, Helm revision history, Certificate Ready, Prometheus targets). Replaced with Flux-correct semantics — GitRepository/Kustomization `Ready=True/False` conditions, kstatus-style `Reconciling` progress, stored-artifact / Applied-revision messages, `spec.suspend` — keeping the sibling's sentence shape. Argo variant untouched.

## Gates
- `pnpm test:labs`: 22/22 pass + `lab-contract: OK — 26 participant labs and sibling solutions` (includes dual-variant `auditGitopsVariantStructure`)
- `pnpm test:inventory`: 6/6 pass + inventory matches validation matrix
- `pnpm lint` (markdownlint-cli2, labs scope): 0 issues in 55 files