### PR TITLE
:bug: fix(deck): fail-closed --gitops parsing + honest S21 flux accuracy locks

### DIFF
--- a/pages/S21-gitops-flux/index.md
+++ b/pages/S21-gitops-flux/index.md
@@ -45,8 +45,9 @@ ACCURACY LOCKS (verified against Flux v2 / GitOps Toolkit docs, 2026-08-06):
   Flux has no separate selfHeal flag; active reconcile *is* the heal).
 - Conditions: kstatus-compatible `Ready` / `Reconciling` / `Stalled` on sources and
   Kustomizations; read with `flux get …` / `kubectl get gitrepository,kustomization`.
-- CLI verbs used on-slide: `flux install`, `flux bootstrap`, `flux get`,
-  `flux reconcile`, `flux suspend`, `flux resume`.
+- CLI verbs used on-slide: `flux install`, `flux get`, `flux reconcile`,
+  `flux suspend`. Speaker-notes-only: `flux bootstrap` (production install path)
+  and `flux resume` (undo suspend) — never shown to learners on a slide.
 - Demo source on-slide: public `stefanprodan/podinfo` (Flux docs example) — hostless,
   kind-friendly. Writable-repo stretch stays a fork, same honesty as the Argo lab.
 

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -719,9 +719,29 @@ describe('S21 GitOps Flux section variant (US-GITOPS-CHOICE-B)', () => {
     assert.match(flux, /labs\/day-3\/21-gitops-flux\.md/)
   })
 
+  // Non-regex HTML-comment strip (indexOf walk): a single-pass regex replace is
+  // flagged by CodeQL as incomplete multi-character sanitization.
+  function stripHtmlComments(markdown) {
+    let visible = ''
+    let cursor = 0
+    while (cursor < markdown.length) {
+      const open = markdown.indexOf('<!--', cursor)
+      if (open < 0) {
+        visible += markdown.slice(cursor)
+        break
+      }
+      visible += markdown.slice(cursor, open)
+      const close = markdown.indexOf('-->', open + '<!--'.length)
+      if (close < 0)
+        break
+      cursor = close + '-->'.length
+    }
+    return visible
+  }
+
   it('locks each claimed on-slide CLI verb into learner-visible content', () => {
     const flux = readFileSync(fluxPath, 'utf8')
-    const visible = flux.replace(/<!--[\s\S]*?-->/g, '')
+    const visible = stripHtmlComments(flux)
 
     for (const verb of ['install', 'get', 'reconcile', 'suspend']) {
       assert.match(
@@ -734,7 +754,7 @@ describe('S21 GitOps Flux section variant (US-GITOPS-CHOICE-B)', () => {
 
   it('keeps bootstrap and resume as speaker-notes-only verbs, per the accuracy locks', () => {
     const flux = readFileSync(fluxPath, 'utf8')
-    const visible = flux.replace(/<!--[\s\S]*?-->/g, '')
+    const visible = stripHtmlComments(flux)
 
     for (const verb of ['bootstrap', 'resume']) {
       assert.doesNotMatch(

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -714,8 +715,89 @@ describe('S21 GitOps Flux section variant (US-GITOPS-CHOICE-B)', () => {
     assert.match(flux, /\bHelmRelease\b/)
     assert.match(flux, /\bprune:\s*true\b/)
     assert.match(flux, /\bsuspend\b/)
-    assert.match(flux, /flux (install|bootstrap|get|reconcile|suspend|resume)/)
     assert.match(flux, /Argo CD/)
     assert.match(flux, /labs\/day-3\/21-gitops-flux\.md/)
+  })
+
+  it('locks each claimed on-slide CLI verb into learner-visible content', () => {
+    const flux = readFileSync(fluxPath, 'utf8')
+    const visible = flux.replace(/<!--[\s\S]*?-->/g, '')
+
+    for (const verb of ['install', 'get', 'reconcile', 'suspend']) {
+      assert.match(
+        visible,
+        new RegExp(`flux ${verb}`),
+        `\`flux ${verb}\` must appear on-slide (outside HTML comments)`,
+      )
+    }
+  })
+
+  it('keeps bootstrap and resume as speaker-notes-only verbs, per the accuracy locks', () => {
+    const flux = readFileSync(fluxPath, 'utf8')
+    const visible = flux.replace(/<!--[\s\S]*?-->/g, '')
+
+    for (const verb of ['bootstrap', 'resume']) {
+      assert.doesNotMatch(
+        visible,
+        new RegExp(`flux ${verb}`),
+        `\`flux ${verb}\` must stay speaker-notes-only; if it moves on-slide, update the locks and this test`,
+      )
+      assert.match(
+        flux,
+        new RegExp(`flux ${verb}`),
+        `\`flux ${verb}\` must still be covered in speaker notes / comments`,
+      )
+    }
+
+    const onSlideClaim = /CLI verbs used on-slide:([\s\S]*?)(?:Speaker-notes-only|\n- |\n\n)/
+      .exec(flux)?.[1] ?? ''
+    assert.notEqual(onSlideClaim, '', 'ACCURACY LOCKS must keep the on-slide CLI verbs claim')
+    assert.doesNotMatch(
+      onSlideClaim,
+      /bootstrap|resume/,
+      'ACCURACY LOCKS must not claim bootstrap/resume as on-slide verbs',
+    )
+    assert.match(
+      flux,
+      /(speaker-)?notes-only:.*`flux bootstrap`.*`flux resume`/is,
+      'ACCURACY LOCKS must name bootstrap/resume as notes-only verbs',
+    )
+  })
+})
+
+describe('generate-decks --gitops parsing (fail closed)', () => {
+  const root = join(import.meta.dirname, '..')
+
+  function runGenerateDecks(args) {
+    return spawnSync(
+      process.execPath,
+      [join(root, 'scripts', 'generate-decks.mjs'), ...args],
+      { cwd: root, encoding: 'utf8' },
+    )
+  }
+
+  it('rejects a bare --gitops flag instead of defaulting silently', () => {
+    const result = runGenerateDecks(['--check', '--gitops'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /missing --gitops value.*argocd.*flux/i)
+  })
+
+  it('rejects a --gitops flag whose value is another flag', () => {
+    const result = runGenerateDecks(['--gitops', '--check'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /missing --gitops value.*argocd.*flux/i)
+  })
+
+  it('rejects duplicate --gitops flags instead of keeping the first', () => {
+    const result = runGenerateDecks(['--check', '--gitops', 'argocd', '--gitops', 'flux'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /--gitops at most once.*argocd.*flux/i)
+  })
+
+  it('rejects invalid --gitops values with a clean message, not a stack trace', () => {
+    const result = runGenerateDecks(['--check', '--gitops', 'both'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /argocd|flux/i)
+    assert.doesNotMatch(result.stderr, /at .*generate-decks\.mjs:\d+/)
   })
 })

--- a/scripts/generate-decks.mjs
+++ b/scripts/generate-decks.mjs
@@ -17,13 +17,24 @@ const repoRoot = resolve(import.meta.dirname, '..')
 const check = process.argv.includes('--check')
 
 function parseGitops(argv) {
-  const index = argv.indexOf('--gitops')
-  if (index < 0)
+  const indexes = argv.flatMap((arg, index) => (arg === '--gitops' ? [index] : []))
+  if (indexes.length === 0)
     return DEFAULT_GITOPS
-  return normalizeGitops(argv[index + 1])
+  if (indexes.length > 1)
+    throw new Error('Pass --gitops at most once; choose exactly one of: argocd, flux')
+  const value = argv[indexes[0] + 1]
+  if (value === undefined || value.startsWith('--'))
+    throw new Error('Missing --gitops value; use exactly one of: argocd, flux')
+  return normalizeGitops(value)
 }
 
-const gitops = parseGitops(process.argv.slice(2))
+let gitops
+try {
+  gitops = parseGitops(process.argv.slice(2))
+} catch (error) {
+  console.error(`decks: ${error.message}`)
+  process.exit(1)
+}
 const resolved = applyGitopsVariant(sections, gitops)
 
 try {


### PR DESCRIPTION
Closes out three P2 findings from the independent reviews of #26 / #27.

## Findings fixed

**A-F1 — `generate-decks.mjs` `--gitops` not fail-closed.** Bare `--gitops` (missing value) silently fell back to the argocd default via `normalizeGitops(undefined)` and exited 0; duplicate `--gitops` flags kept the first value and exited 0. Both now error with launcher-consistent messages and exit 1; invalid values (`both`, `tekton`, ...) print a clean `decks:` error instead of an uncaught stack trace. `scripts/deck.mjs` was checked for the same hole — it parses via `deck-selector.mjs`, which already rejects both cases, so no change needed there.

**B-F1 — ACCURACY LOCKS overstated on-slide CLI verbs.** `pages/S21-gitops-flux/index.md` claimed `flux bootstrap` and `flux resume` appear on-slide; both live only in speaker notes / HTML comments. The lock now lists `flux install` / `get` / `reconcile` / `suspend` as on-slide and names `bootstrap` / `resume` as speaker-notes-only. Docs-honesty fix only — no slide content changed.

**B-F2 — vocabulary test was a weak OR.** The CHOICE-B test matched `flux (install|bootstrap|get|reconcile|suspend|resume)` as an OR, so `flux install` alone satisfied it. Now: per-verb asserts that install/get/reconcile/suspend appear in learner-visible content (HTML comments stripped), that bootstrap/resume stay notes-only (present in comments, absent from visible content), and that the LOCKS on-slide claim never names notes-only verbs. Plus spawned-process tests locking generate-decks exit-1 behavior for bare, flag-valued, duplicate, and invalid `--gitops`.

## Gates

- `pnpm test:deck`: 46/46 pass
- `pnpm decks:check`: current (6 entries, 28 sections, gitops=argocd)
- `pnpm build` (full: decks:check + day1/day2/day3/optional): pass
- Byte-identity: default regenerate produces empty `git diff` on all `slides-*.md`, including after a `--gitops flux` generate + `decks:check --gitops flux` round-trip
- Repros now fail closed: `node scripts/generate-decks.mjs --check --gitops` → exit 1; `--check --gitops argocd --gitops flux` → exit 1