### PR TITLE
:bug: fix(infra): day-3 teardown detects installed gitops tool (D-F1) + preflight transition bats (D-F2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ profile-day-1-down: ## Tear down day-1 composed components
 profile-day-2-down: ## Tear down day-2 composed components
 	@infra/addons/profile.sh day-2 --teardown
 
-profile-day-3-down: ## Tear down day-3 composed components (GITOPS=flux to match install)
+profile-day-3-down: ## Tear down day-3 composed components (auto-detects installed GitOps tool)
 	@infra/addons/profile.sh day-3 $(if $(GITOPS),--gitops $(GITOPS),) --teardown
 
 profile-gateway-envoy: ## Install Envoy Gateway profile (S09; exclusive vs Contour)

--- a/infra/addons/profile.sh
+++ b/infra/addons/profile.sh
@@ -59,6 +59,8 @@ GitOps tools (mutually exclusive — never install Argo CD and Flux together):
 
   day-3 --gitops argocd      default S21 path (Argo CD)
   day-3 --gitops flux        Flux variant for S21
+  day-3 --teardown           auto-detects the installed GitOps tool; an explicit
+                             --gitops that contradicts the cluster fails loudly
   transition argocd|flux     safe Argo ↔ Flux switch (refuses silent dual install)
 
 Interactive gum choose is progressive enhancement; flags/non-TTY behave identically.
@@ -109,6 +111,41 @@ day3_components() {
   local tool="${GITOPS_TOOL:-argocd}"
   printf '%s\n' "$tool"
   printf '%s\n' "${DAY3_SHARED[@]}"
+}
+
+# Teardown must remove what is ACTUALLY installed, not what --gitops claims —
+# a bare `day-3 --teardown` after a Flux install must not leave Flux behind.
+# Prints the GitOps tool to tear down (empty = skip the GitOps component);
+# fails loudly on contradiction/conflict BEFORE anything is torn down.
+resolve_day3_teardown_tool() {
+  local active
+  active="$(gitops_detect)"
+  case "$active" in
+    argocd | flux)
+      if [ "${GITOPS_TOOL_EXPLICIT:-0}" = "1" ] && [ "${GITOPS_TOOL:-argocd}" != "$active" ]; then
+        addons_err "refusing teardown: --gitops ${GITOPS_TOOL} contradicts installed GitOps tool '${active}'"
+        addons_err "Remediation: ./workshop profile day-3 --gitops ${active} --teardown"
+        addons_err "  # or omit --gitops — teardown auto-detects the installed tool"
+        return 1
+      fi
+      printf '%s\n' "$active"
+      ;;
+    none)
+      addons_warn "no workshop GitOps tool detected — skipping GitOps component teardown"
+      ;;
+    foreign-argocd | foreign-flux)
+      addons_warn "foreign/unowned GitOps install detected (${active}) — not workshop-managed, leaving it in place"
+      ;;
+    conflict)
+      addons_err "cluster reports both Argo CD and Flux — refusing day-3 teardown"
+      addons_err "Remediation: manually remove one stack, or recreate the kind cluster"
+      return 1
+      ;;
+    *)
+      addons_err "unexpected GitOps detect state: ${active}"
+      return 1
+      ;;
+  esac
 }
 
 components_for_profile() {
@@ -213,10 +250,20 @@ cmd_teardown_profile() {
     return 2
   fi
 
-  # Tear down in reverse composition order.
-  while IFS= read -r comp; do
-    comps+=("$comp")
-  done < <(components_for_profile "$profile")
+  # Tear down in reverse composition order. day-3 detects the installed
+  # GitOps tool instead of trusting --gitops (which parameterizes install).
+  if [ "$profile" = "day-3" ]; then
+    local tool
+    tool="$(resolve_day3_teardown_tool)" || return 1
+    if [ -n "$tool" ]; then
+      comps+=("$tool")
+    fi
+    comps+=("${DAY3_SHARED[@]}")
+  else
+    while IFS= read -r comp; do
+      comps+=("$comp")
+    done < <(components_for_profile "$profile")
+  fi
 
   local i
   for ((i = ${#comps[@]} - 1; i >= 0; i--)); do
@@ -337,11 +384,13 @@ main() {
       --gitops)
         shift || true
         GITOPS_TOOL="$(parse_gitops_tool "${1:-}")" || return 2
-        export GITOPS_TOOL
+        GITOPS_TOOL_EXPLICIT=1
+        export GITOPS_TOOL GITOPS_TOOL_EXPLICIT
         ;;
       --gitops=*)
         GITOPS_TOOL="$(parse_gitops_tool "${1#--gitops=}")" || return 2
-        export GITOPS_TOOL
+        GITOPS_TOOL_EXPLICIT=1
+        export GITOPS_TOOL GITOPS_TOOL_EXPLICIT
         ;;
       -h | --help) usage; return 0 ;;
       *) args+=("$1") ;;

--- a/infra/tests/gitops-profiles.bats
+++ b/infra/tests/gitops-profiles.bats
@@ -271,6 +271,56 @@ EOF
   ! echo "$ADDON_MARKERS" | grep -q "monitoring:kube-prometheus"
 }
 
+# --- D-F2: transition refuse paths (gitops-preflight.sh) --------------------
+
+@test "transition refuses when both Argo CD and Flux are present (conflict)" {
+  export MOCK_ROUTING_NAMESPACES="argocd flux-system"
+  export MOCK_ADDON_MARKERS="argocd:argocd flux-system:flux"
+
+  run "$ROOT/infra/addons/profile.sh" transition flux
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "both"
+  echo "$output" | grep -qi "remediat"
+  [ ! -s "$MOCK_ROUTING_APPLY_LOG" ]
+  # Neither stack was torn down.
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  echo "$ADDON_MARKERS" | grep -q "argocd:argocd"
+  echo "$ADDON_MARKERS" | grep -q "flux-system:flux"
+}
+
+@test "transition to flux refuses foreign Argo CD (unowned namespace)" {
+  export MOCK_ROUTING_NAMESPACES="argocd"
+  export MOCK_ADDON_DEPLOYS="argocd:argocd-server"
+
+  run "$ROOT/infra/addons/profile.sh" transition flux
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "foreign\|unowned"
+  echo "$output" | grep -qi "remediat"
+  [ ! -s "$MOCK_ROUTING_APPLY_LOG" ]
+}
+
+@test "transition to argocd refuses foreign Flux (unowned namespace)" {
+  export MOCK_ROUTING_NAMESPACES="flux-system"
+  export MOCK_ADDON_DEPLOYS="flux-system:source-controller"
+
+  run "$ROOT/infra/addons/profile.sh" transition argocd
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "foreign\|unowned"
+  echo "$output" | grep -qi "remediat"
+  [ ! -s "$MOCK_ROUTING_APPLY_LOG" ]
+}
+
+@test "transition to flux refuses foreign Flux (unowned namespace, no adopt)" {
+  export MOCK_ROUTING_NAMESPACES="flux-system"
+  export MOCK_ADDON_DEPLOYS="flux-system:source-controller"
+
+  run "$ROOT/infra/addons/profile.sh" transition flux
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "foreign\|unowned"
+  [ ! -s "$MOCK_ROUTING_APPLY_LOG" ]
+}
+
 @test "profile help documents --gitops and argocd/flux mutex" {
   run "$ROOT/infra/addons/profile.sh" --help
   [ "$status" -eq 0 ]

--- a/infra/tests/gitops-profiles.bats
+++ b/infra/tests/gitops-profiles.bats
@@ -271,6 +271,84 @@ EOF
   ! echo "$ADDON_MARKERS" | grep -q "monitoring:kube-prometheus"
 }
 
+# --- D-F1: day-3 teardown must remove what is actually installed ------------
+
+@test "day-3 teardown without --gitops removes installed flux (auto-detect)" {
+  run "$ROOT/infra/addons/profile.sh" day-3 --gitops flux
+  [ "$status" -eq 0 ]
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --teardown
+  [ "$status" -eq 0 ]
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  # NOTE: `! cmd` never fails a bats test — use grep -c for negative asserts.
+  [ "$(echo "$ADDON_MARKERS" | grep -c "flux-system:flux")" -eq 0 ]
+  [ "$(echo "$ADDON_MARKERS" | grep -c "cert-manager:cert-manager")" -eq 0 ]
+  [ "$(echo "$ADDON_MARKERS" | grep -c "monitoring:kube-prometheus")" -eq 0 ]
+}
+
+@test "day-3 teardown --gitops argocd refuses when flux is installed" {
+  export MOCK_ROUTING_NAMESPACES="flux-system"
+  export MOCK_ADDON_MARKERS="flux-system:flux cert-manager:cert-manager monitoring:kube-prometheus"
+  export MOCK_ADDON_DEPLOYS="flux-system:source-controller"
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --gitops argocd --teardown
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "flux"
+  echo "$output" | grep -qi "contradict\|mismatch\|refus"
+  echo "$output" | grep -qi "remediat"
+  # Refusal happens before any component teardown — nothing removed.
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  echo "$ADDON_MARKERS" | grep -q "flux-system:flux"
+  echo "$ADDON_MARKERS" | grep -q "cert-manager:cert-manager"
+  echo "$ADDON_MARKERS" | grep -q "monitoring:kube-prometheus"
+}
+
+@test "day-3 teardown --gitops flux refuses when argocd is installed" {
+  export MOCK_ROUTING_NAMESPACES="argocd"
+  export MOCK_ADDON_MARKERS="argocd:argocd"
+  export MOCK_ADDON_DEPLOYS="argocd:argocd-server"
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --gitops flux --teardown
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "argocd"
+  echo "$output" | grep -qi "contradict\|mismatch\|refus"
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  echo "$ADDON_MARKERS" | grep -q "argocd:argocd"
+}
+
+@test "day-3 teardown refuses when both Argo CD and Flux are present" {
+  export MOCK_ROUTING_NAMESPACES="argocd flux-system"
+  export MOCK_ADDON_MARKERS="argocd:argocd flux-system:flux"
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --teardown
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi "both\|conflict"
+  echo "$output" | grep -qi "remediat"
+}
+
+@test "day-3 teardown skips foreign flux but removes shared components" {
+  export MOCK_ROUTING_NAMESPACES="flux-system"
+  export MOCK_ADDON_MARKERS="cert-manager:cert-manager monitoring:kube-prometheus"
+  export MOCK_ADDON_DEPLOYS="flux-system:source-controller"
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --teardown
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "foreign\|unowned"
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  echo "$ADDON_DEPLOYS" | grep -q "flux-system:source-controller"
+  [ "$(echo "$ADDON_MARKERS" | grep -c "cert-manager:cert-manager")" -eq 0 ]
+  [ "$(echo "$ADDON_MARKERS" | grep -c "monitoring:kube-prometheus")" -eq 0 ]
+}
+
+@test "day-3 teardown on an empty cluster succeeds" {
+  run "$ROOT/infra/addons/profile.sh" day-3 --teardown
+  [ "$status" -eq 0 ]
+}
+
 # --- D-F2: transition refuse paths (gitops-preflight.sh) --------------------
 
 @test "transition refuses when both Argo CD and Flux are present (conflict)" {


### PR DESCRIPTION
Closes out the two P2 findings from the independent review of PR #29 (US-GITOPS-CHOICE-D).

## D-F1 — day-3 teardown `--gitops` footgun
A bare `day-3 --teardown` (or `make profile-day-3-down` without `GITOPS=flux`) after a Flux day-3 install composed the default argocd teardown and silently left Flux behind. Teardown now resolves the GitOps component from the cluster via the existing `gitops_detect` probe before touching anything:

- installed workshop tool → torn down regardless of the flag default
- explicit `--gitops` contradicting the installed tool → loud refusal with remediation, before any component is removed
- conflict (both stacks present) → loud refusal with remediation
- foreign/unowned install → warn and leave it in place; shared components (cert-manager, kube-prometheus) still torn down
- none → skip the GitOps component with a warning

Install-path behavior is unchanged. Makefile help text and profile usage updated.

## D-F2 — transition refuse paths now bats-covered
`gitops_transition` conflict and foreign/unowned refuse branches (infra/addons/gitops-preflight.sh) had no bats coverage. Added mocked-kubectl tests asserting non-zero exit, remediation text, and zero mutation (empty apply log, markers intact).

## Gates
- shellcheck (CI-equivalent: all infra `*.sh`/`*.bash`, test stubs, `./workshop`, release helpers): clean
- full infra bats suite: 213/213 ok (12 new tests: 6 D-F1, 4 D-F2, plus contradiction/empty-cluster regressions)
- TDD: D-F1 tests written first and confirmed red against the old teardown before the fix; D-F2 tests pin existing refusal behavior

No live cluster used — mocked kubectl only.