### PR TITLE
:adhesive_bandage: chore(sweep): close P3 review leftovers from #30-#32

### DIFF
--- a/infra/addons/README.md
+++ b/infra/addons/README.md
@@ -31,6 +31,15 @@ these** — pick a named profile when a lab day needs controllers.
   Preflight refuses a dual install; use `transition` for a safe switch. The day-3
   `--gitops` flag matches the deck launcher spelling (`argocd` default; `flux`
   selectable) so facilitator flags stay aligned across slides and infra.
+- **Day-3 teardown removes what is actually installed**, not what `--gitops`
+  claims. A bare `./workshop profile day-3 --teardown` auto-detects the
+  installed GitOps tool and tears it down; an explicit `--gitops` that
+  contradicts the cluster (e.g. `--gitops argocd` while Flux is installed)
+  fails loudly *before* anything is removed, as does a conflict (both tools
+  present). Foreign/unowned installs (namespace without the workshop ownership
+  marker) are left in place while the shared day-3 components (`cert-manager`,
+  `kube-prometheus`) are still removed; if no GitOps tool is detected, the
+  GitOps step is skipped and only the shared components are torn down.
 - Each component: preflight/`check`, apply, bounded readiness wait, ownership
   marker, idempotent re-run, scoped teardown.
 - Versions from `infra/versions.env`. Interactive `gum` choose is progressive

--- a/infra/tests/gitops-profiles.bats
+++ b/infra/tests/gitops-profiles.bats
@@ -281,8 +281,22 @@ EOF
   [ "$status" -eq 0 ]
   # shellcheck disable=SC1090
   . "$MOCK_ROUTING_STATE"
-  # NOTE: `! cmd` never fails a bats test — use grep -c for negative asserts.
+  # NOTE: a non-final `! cmd` line doesn't fail a bats test (only final-line
+  # negation does) — use grep -c for negative asserts.
   [ "$(echo "$ADDON_MARKERS" | grep -c "flux-system:flux")" -eq 0 ]
+  [ "$(echo "$ADDON_MARKERS" | grep -c "cert-manager:cert-manager")" -eq 0 ]
+  [ "$(echo "$ADDON_MARKERS" | grep -c "monitoring:kube-prometheus")" -eq 0 ]
+}
+
+@test "day-3 teardown without --gitops removes installed argocd (auto-detect)" {
+  run "$ROOT/infra/addons/profile.sh" day-3
+  [ "$status" -eq 0 ]
+
+  run "$ROOT/infra/addons/profile.sh" day-3 --teardown
+  [ "$status" -eq 0 ]
+  # shellcheck disable=SC1090
+  . "$MOCK_ROUTING_STATE"
+  [ "$(echo "$ADDON_MARKERS" | grep -c "argocd:argocd")" -eq 0 ]
   [ "$(echo "$ADDON_MARKERS" | grep -c "cert-manager:cert-manager")" -eq 0 ]
   [ "$(echo "$ADDON_MARKERS" | grep -c "monitoring:kube-prometheus")" -eq 0 ]
 }

--- a/labs/day-3/21-gitops.solution.md
+++ b/labs/day-3/21-gitops.solution.md
@@ -321,9 +321,10 @@ Clean up the fork path the same way: `kubectl -n argocd delete application guest
 - **Drift detection ≠ self-heal.** With `selfHeal: false`, the same drift stays `OutOfSync` and is
   *not* reverted — detection always runs; self-heal is the auto-fix on top.
 
-Representative statuses include Ready/Running Pods, NetworkPolicy timeouts, RBAC Forbidden,
-Helm revision history, Application Synced/Healthy, Certificate Ready, or Prometheus targets —
-compare meaning, not ephemeral names.
+Representative statuses include Ready/Running Pods, Application `Synced/OutOfSync` sync
+statuses, `Healthy/Progressing` health statuses, drift held at `OutOfSync` while
+`selfHeal: false` and auto-reverted once `selfHeal: true`, and the last-sync revision
+message — compare meaning, not ephemeral values (revision SHAs, Pod-name suffixes, ages).
 
 ## Explanation
 

--- a/scripts/deck-selector.mjs
+++ b/scripts/deck-selector.mjs
@@ -35,6 +35,8 @@ export function parseSelection(args) {
       action = args[++i]
       if (!['dev', 'build', 'export'].includes(action))
         throw new Error(`Invalid action ${action ?? '(missing)'}; use dev, build, or export`)
+    } else if (arg.startsWith('--gitops=')) {
+      throw new Error(`Unsupported ${arg}; use --gitops <value> with exactly one of: argocd, flux`)
     } else if (arg === '--list') list = true
     else if (arg === '--dry-run') dryRun = true
     else if (arg === '--help' || arg === '-h') help = true

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -540,6 +540,13 @@ describe('deck selection', () => {
     )
   })
 
+  it('rejects the equals form --gitops=flux with guidance toward --gitops <value>', () => {
+    assert.throws(
+      () => parseSelection(['--day', '3', '--gitops=flux']),
+      /use --gitops <value>/i,
+    )
+  })
+
   it('rejects reversed, unknown, and malformed contiguous ranges', () => {
     for (const range of ['S03-S01', 'S00-S99', 'S00,S02']) {
       const selection = parseSelection(['--range', range])
@@ -819,5 +826,17 @@ describe('generate-decks --gitops parsing (fail closed)', () => {
     assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
     assert.match(result.stderr, /argocd|flux/i)
     assert.doesNotMatch(result.stderr, /at .*generate-decks\.mjs:\d+/)
+  })
+
+  it('rejects the equals form --gitops=flux instead of silently defaulting to argocd', () => {
+    const result = runGenerateDecks(['--check', '--gitops=flux'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /use --gitops <value>/i)
+  })
+
+  it('rejects unknown options such as a typo of --gitops instead of exiting 0', () => {
+    const result = runGenerateDecks(['--check', '--gitpos', 'flux'])
+    assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
+    assert.match(result.stderr, /unknown option --gitpos/i)
   })
 })

--- a/scripts/generate-decks.mjs
+++ b/scripts/generate-decks.mjs
@@ -14,23 +14,36 @@ import {
 } from './deck-manifest.mjs'
 
 const repoRoot = resolve(import.meta.dirname, '..')
-const check = process.argv.includes('--check')
 
-function parseGitops(argv) {
-  const indexes = argv.flatMap((arg, index) => (arg === '--gitops' ? [index] : []))
-  if (indexes.length === 0)
-    return DEFAULT_GITOPS
-  if (indexes.length > 1)
-    throw new Error('Pass --gitops at most once; choose exactly one of: argocd, flux')
-  const value = argv[indexes[0] + 1]
-  if (value === undefined || value.startsWith('--'))
-    throw new Error('Missing --gitops value; use exactly one of: argocd, flux')
-  return normalizeGitops(value)
+function parseArgs(argv) {
+  let check = false
+  let gitops = DEFAULT_GITOPS
+  let gitopsSet = false
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--check') {
+      check = true
+    } else if (arg === '--gitops') {
+      if (gitopsSet)
+        throw new Error('Pass --gitops at most once; choose exactly one of: argocd, flux')
+      gitopsSet = true
+      const value = argv[++i]
+      if (value === undefined || value.startsWith('--'))
+        throw new Error('Missing --gitops value; use exactly one of: argocd, flux')
+      gitops = normalizeGitops(value)
+    } else if (arg.startsWith('--gitops=')) {
+      throw new Error(`Unsupported ${arg}; use --gitops <value> with exactly one of: argocd, flux`)
+    } else {
+      throw new Error(`Unknown option ${arg}; supported: --check, --gitops <argocd|flux>`)
+    }
+  }
+  return { check, gitops }
 }
 
+let check
 let gitops
 try {
-  gitops = parseGitops(process.argv.slice(2))
+  ({ check, gitops } = parseArgs(process.argv.slice(2)))
 } catch (error) {
   console.error(`decks: ${error.message}`)
   process.exit(1)


### PR DESCRIPTION
Closes the P3 leftovers filed by independent reviewers on merged PRs #30/#31/#32.

## Changes

1. **CLI equals-syntax fail-closed** (`scripts/generate-decks.mjs`, `scripts/deck-selector.mjs`): `--gitops=flux` and typo flags like `--gitpos` no longer silently default to argocd and exit 0. `generate-decks.mjs` now rejects any unknown option (matching the deck-selector convention), and both parsers reject the `--gitops=` equals form with explicit guidance to use `--gitops <value>`. TDD: three new locks in `scripts/deck.test.mjs` (red before fix).
2. **Argo solution status parity** (`labs/day-3/21-gitops.solution.md`): replaced generic cross-lab status boilerplate (NetworkPolicy timeouts, RBAC Forbidden, Helm revisions, Certificate Ready, Prometheus targets) with Argo-CD-correct representative statuses (Synced/OutOfSync, Healthy/Progressing, selfHeal semantics), mirroring the PR #30 shape used in the Flux sibling. Flux files untouched.
3. **Teardown semantics documented** (`infra/addons/README.md`): day-3 teardown auto-detect, contradiction/conflict refusal before any removal, foreign installs left in place while shared components are removed, none-detected skip.
4. **Missing bats cell** (`infra/tests/gitops-profiles.bats`): bare `day-3 --teardown` with Argo CD installed (auto-detect), mirroring the existing flux cell. Mocked kubectl only.
5. **Comment accuracy** (`infra/tests/gitops-profiles.bats`): softened the overbroad "`! cmd` never fails a bats test" note to the accurate non-final-line wording.

## Gates

- `pnpm test:deck` 49/49
- `pnpm test:labs` 22/22, `pnpm test:inventory` 6/6
- `bats infra/tests` 214/214
- `pnpm decks:check` green; regenerate leaves `slides-*.md` byte-identical (empty diff)
- markdownlint clean on changed .md files