### PR TITLE
:memo: docs: fix three release-readiness honesty defects (roadmap, matrix, facilitator guide)

### DIFF
--- a/docs/facilitator-guide.md
+++ b/docs/facilitator-guide.md
@@ -286,7 +286,7 @@ reason to re-paste a beta warning on the README or docs landing.
 | Status | Item | Story / note |
 | --- | --- | --- |
 | Backlog | Full clean-environment rehearsal | **US-BETA-6** — useful for facilitators who want a recorded run; syllabus minutes stay planning aids, not a contract |
-| Backlog | Validation matrix → `kind-smoke` | **US-ENV-4** Day-2/3 drivers + recorded evidence |
+| Backlog | Validation matrix → `kind-smoke` for the Day-2/3 drivers | **US-ENV-4** Day-2/3 drivers + recorded evidence; the Flux S21 variant row is already promoted |
 | Accepted deferred | S24 kubebuilder | **US-S24** — see [known limitations](./beta-limitations.md) |
 | Done | Repo description + topics | **US-BETA-2** |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,13 @@ summarizes; it does not lead over private trackers.
 
 ## Direction
 
+> **No longer listed here: GitOps tool choice.** It is on `main`, not direction —
+> the GitOps section (S21) ships with **Argo CD as the default** and **Flux as a
+> selectable variant**, so facilitators can match the tool their room actually
+> uses without forking the curriculum. Choose one per delivery with
+> `--gitops argocd|flux`; see [running the slides](./run-slides.md).
+> [Discuss GitOps tool choice →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/22)
+
 ### Live quizzes — planned
 
 Per-section retrieval questions plus a self-hosted live-quiz add-on for the room.
@@ -29,14 +36,6 @@ none of them (0/3)** — so the live host and full question bank remain **planne
 with architecture still open.
 
 [Discuss live quizzes →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/21)
-
-### GitOps tool choice — planned
-
-Deliver the GitOps section with **Argo CD as the default** and **Flux as a
-selectable variant**, so facilitators can match the tool their room actually
-uses without forking the curriculum.
-
-[Discuss GitOps tool choice →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/22)
 
 ### OpenTelemetry — exploring
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,13 @@ direction, not delivery.
 Internal planning notes (if any) stay out of the published site. This page
 summarizes; it does not lead over private trackers.
 
+> **GitOps tool choice is on `main`, not direction.** The GitOps section (S21)
+> ships with **Argo CD as the default** and **Flux as a selectable variant**, so
+> facilitators can match the tool their room actually uses without forking the
+> curriculum. Choose one per delivery with `--gitops argocd|flux`; see
+> [running the slides](./run-slides.md).
+> [Discuss GitOps tool choice →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/22)
+
 ## Status vocabulary
 
 | Status | Meaning |
@@ -18,13 +25,6 @@ summarizes; it does not lead over private trackers.
 | **exploring** | Under consideration only — explicitly **not** committed. |
 
 ## Direction
-
-> **No longer listed here: GitOps tool choice.** It is on `main`, not direction —
-> the GitOps section (S21) ships with **Argo CD as the default** and **Flux as a
-> selectable variant**, so facilitators can match the tool their room actually
-> uses without forking the curriculum. Choose one per delivery with
-> `--gitops argocd|flux`; see [running the slides](./run-slides.md).
-> [Discuss GitOps tool choice →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/22)
 
 ### Live quizzes — planned
 

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -166,8 +166,11 @@ v1.8.2** (GatewayClass `eg`), and every demo web image is the purpose-built
 `ghcr.io/platformrelay/workshop-web` (`:v1`/`:v2`/`:v3`, port **8080**, non-root, distroless,
 PSA `restricted`-clean, with native `/healthz`, `/ready`, `POST /fail|/recover` probe
 endpoints). The S08/S09 rows above reflect the new stack; defect **D1** is retained as
-resolved history. All rows stay `unrun`/`server-dry-run` until the US-BETA-6 rehearsal /
-US-ENV-4 smoke re-runs them against the new stack.
+resolved history. Both of those rows stay `unrun` until the US-BETA-6 rehearsal /
+US-ENV-4 smoke re-runs them against the new stack. Elsewhere in the matrix exactly one
+row sits above that line — the Flux S21 variant's maintainer-recorded `kind-smoke`, per
+the honesty rule above — and every other row remains `unrun`/`server-dry-run`, with the
+unauthored S24 stub `deferred`.
 
 ## What this matrix feeds
 

--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -168,9 +168,9 @@ PSA `restricted`-clean, with native `/healthz`, `/ready`, `POST /fail|/recover` 
 endpoints). The S08/S09 rows above reflect the new stack; defect **D1** is retained as
 resolved history. Both of those rows stay `unrun` until the US-BETA-6 rehearsal /
 US-ENV-4 smoke re-runs them against the new stack. Elsewhere in the matrix exactly one
-row sits above that line — the Flux S21 variant's maintainer-recorded `kind-smoke`, per
-the honesty rule above — and every other row remains `unrun`/`server-dry-run`, with the
-unauthored S24 stub `deferred`.
+row is promoted past the `unrun`/`server-dry-run` band — the Flux S21 variant's
+maintainer-recorded `kind-smoke`, per the honesty rule above — and every other row
+remains `unrun`/`server-dry-run`, with the unauthored S24 stub `deferred`.
 
 ## What this matrix feeds
 


### PR DESCRIPTION
Three documentation-honesty defects found by a release-readiness audit. All three are wrong on `main` today, independent of whether a release is cut.

## R2 (P1) — public roadmap called shipped work "planned"

`docs/roadmap.md` still headed **"GitOps tool choice — planned"** and described Argo-CD-default-with-Flux-variant as future work. That work is on `main`: `pages/S21-gitops-flux/index.md`, `labs/day-3/21-gitops-flux.md` (+ solution), `DEFAULT_GITOPS = 'argocd'` with an `argocd|flux` variant switch in `scripts/deck-manifest.mjs`, and the `--gitops` flag documented in `docs/run-slides.md` — all landed after `e118a03` (the commit that published the roadmap page).

The item is removed from `## Direction` entirely and replaced by a short pointer callout in the page intro (above `## Status vocabulary`, outside any status-bearing section). No new status word was invented and the status-vocabulary table / intro sentence are untouched: `## Direction` now holds only `planned` / `exploring` items, exactly as the page defines them. No dates, no commitments. The Discussion-22 link survives.

`docs/release.md`'s pre-tag checklist (item 2) mandates this re-verification in the release window.

## R4 (P2) — validation matrix contradicted itself

`docs/validation-matrix.md` asserted **"All rows stay `unrun`/`server-dry-run`"** in the US-NGX note, contradicting the Flux S21 row in the same file, which is `kind-smoke`. Commit `fd20fa9` updated the legend and the honesty rule but missed this paragraph.

The sentence is narrowed to the S08/S09 rows it is actually about, and the one genuine exception is named: the Flux S21 variant's maintainer-recorded `kind-smoke`, *per the honesty rule above*. The no-auto-promotion rule is referenced, not restated and not relaxed — the legend, the honesty rule, and the "What this matrix feeds" section remain the only places that state it.

## R5 (P3) — facilitator guide mis-scoped the same item

`docs/facilitator-guide.md` filed "Validation matrix → `kind-smoke`" as untouched Backlog, reading as "zero rows promoted". The cell is now scoped to the Day-2/3 drivers and notes that the Flux S21 row is already promoted (phrased around promotion, not evidence — S08 has live evidence recorded elsewhere in the same guide without a promoted row).

## Gates

| Gate | Result |
| --- | --- |
| `pnpm lint` | pass (0 issues; note the config globs `labs/**` only, so it does not cover these three files) |
| `pnpm link-check` | pass — 14 docs, all internal links and anchors resolve (the removed `### GitOps tool choice — planned` heading had no inbound anchors) |
| `pnpm test:pages` | pass — 15/15 |
| `pnpm test:inventory` | pass — 6/6 + `infra/lab-inventory.json` matches `docs/validation-matrix.md` |

**Known-red CI step, not caused by this branch:** `node scripts/dependency-audit.mjs` exits 1 on `main` because of js-yaml advisory GHSA-5p4m-2wfm-xmqj, published after the last green CI run. A separate lane owns that fix; nothing here touches `pnpm-workspace.yaml` or `pnpm-lock.yaml`.

Docs-only. `docs/downloads.md` deliberately untouched — its version pins are held pending an operator decision.
