### PR TITLE
:lock: fix(deps): pin js-yaml 3.x/4.x to GHSA-5p4m-2wfm-xmqj patched floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   postcss: 8.5.25
   js-yaml@>=5.0.0 <6.0.0: 5.2.3
+  js-yaml@>=4.0.0 <5.0.0: 4.3.1
+  js-yaml@>=3.0.0 <4.0.0: 3.15.1
   dompurify: 3.4.13
   '@hono/node-server': 2.1.0
 
@@ -2098,12 +2100,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.2.3:
@@ -3466,7 +3468,7 @@ snapshots:
   '@comark/markdown-it@0.3.4(@types/markdown-it@14.1.2)(markdown-it@14.3.0)':
     dependencies:
       '@types/markdown-it': 14.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       markdown-it: 14.3.0
 
   '@devframes/hub@0.7.16(devframe@0.7.16(cac@7.0.0)(srvx@0.12.5)(typescript@6.0.3))':
@@ -5507,7 +5509,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -5647,12 +5649,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,12 @@ overrides:
   # markdownlint 5.x line patched without forcing its unrelated 3.x/4.x users
   # across a major-version boundary.
   "js-yaml@>=5.0.0 <6.0.0": 5.2.3
+  # GHSA-5p4m-2wfm-xmqj (CVE-2026-59870) hits both the 3.x and 4.x js-yaml
+  # lines that @slidev/cli pulls in transitively. The fix was released on each
+  # line separately, so pin each range to its own first patched version rather
+  # than dragging Slidev's YAML parser across a major-version boundary.
+  "js-yaml@>=4.0.0 <5.0.0": 4.3.1
+  "js-yaml@>=3.0.0 <4.0.0": 3.15.1
   # monaco-editor / mermaid pull older DOMPurify; pin the patched line.
   dompurify: 3.4.13
   # Dependabot/GHSA collapses @hono/node-server to "<2.0.5" even though

--- a/supply-chain/dependency-advisories.json
+++ b/supply-chain/dependency-advisories.json
@@ -1,5 +1,5 @@
 {
-  "captured": "2026-08-04",
+  "captured": "2026-08-07",
   "source": "GitHub Global Security Advisory API",
   "advisories": [
     {
@@ -19,6 +19,24 @@
       "vulnerableVersionRange": ">= 5.0.0, <= 5.2.1",
       "firstPatchedVersion": "5.2.2",
       "source": "https://github.com/advisories/GHSA-pm4m-ph32-ghv5"
+    },
+    {
+      "id": "GHSA-5p4m-2wfm-xmqj",
+      "package": "js-yaml",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 3.0.0, < 3.15.1",
+      "firstPatchedVersion": "3.15.1",
+      "source": "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj"
+    },
+    {
+      "id": "GHSA-5p4m-2wfm-xmqj",
+      "package": "js-yaml",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
+      "firstPatchedVersion": "4.3.1",
+      "source": "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj"
     }
   ]
 }


### PR DESCRIPTION
## Why main looks green but CI is red

`GHSA-5p4m-2wfm-xmqj` (CVE-2026-59870) was published **after** the last CI run on `7895081`, so that green tick is stale. `node scripts/dependency-audit.mjs` — a blocking step in `.github/workflows/ci.yml` — fails on current `main` today:

```
Audit counts: critical=0, high=2, moderate=5, low=1
GHSA-5p4m-2wfm-xmqj: js-yaml (high) — Quadratic CPU consumption in !!omap resolution (3.x and 4.x)   [x2]
```

Both vulnerable copies are transitive under `@slidev/cli`. This blocks CI for every other open PR and for the pending release.

## The fix

The advisory fixed the 3.x and 4.x lines separately, so each range is pinned to its own first patched version rather than dragged across a major boundary — matching the existing 5.x override precedent in `pnpm-workspace.yaml`:

| range | pinned to | first patched (per GitHub API) |
| --- | --- | --- |
| `js-yaml@>=4.0.0 <5.0.0` | `4.3.1` | `4.3.1` |
| `js-yaml@>=3.0.0 <4.0.0` | `3.15.1` | `3.15.1` |

No `minimumReleaseAgeExclude` entries are needed: `pnpm config get minimumReleaseAge` returns `undefined` in this repo, and both patches were published 2026-07-31 (7 days ago) regardless.

## Second commit: locked advisory evidence

`supply-chain/dependency-advisories.json` is outside the paths this lane was originally scoped to; it was granted after checking the convention, and is a **separate commit** so it can be dropped independently.

The convention does require it. Every high-severity advisory that motivated an override has an entry (postcss `GHSA-r28c-9q8g-f849`, js-yaml 5.x `GHSA-pm4m-ph32-ghv5`). The `dompurify` and `@hono/node-server` overrides have none because those advisories are low/medium and `evaluateLockedAdvisories` rejects anything outside `BLOCKED_SEVERITIES` (`high`/`critical`). Without an entry, the only thing preventing a lockfile regression to `4.3.0` is a live registry call — which defeats the point of a hermetic check that runs *first*.

`captured` moves to `2026-08-07` honestly: ranges, patched floors and severities for **all three** entries were re-verified today against the GitHub Global Security Advisory API (`gh api graphql securityAdvisory`), not just the new one.

## Verification

| gate | result |
| --- | --- |
| `node scripts/dependency-audit.mjs` (before) | exit **1** — `critical=0, high=2, moderate=5, low=1` |
| `node scripts/dependency-audit.mjs` (after) | exit **0** — `critical=0, high=0, moderate=5, low=1` |
| `pnpm install --frozen-lockfile` (CI parity) | pass |
| `pnpm decks:check` | pass — 6 entries, 28 sections, gitops=argocd |
| `pnpm build` | pass — all decks built |
| `pnpm test:deck` | pass — 49/49 |
| `pnpm test:pages` | pass — 15/15 |
| `pnpm lint` | pass — 0 issues in 55 files |
| `node --test scripts/dependency-audit.test.mjs` | pass — 21/21 |
| `node --test scripts/supply-chain-policy.test.mjs` | pass — 34/34 |

**The override provably applied** — all three lockfile facts, not just `pnpm why`:
1. the overrides echo at the top of `pnpm-lock.yaml` lists both new ranged keys;
2. no `js-yaml@3.15.0` / `js-yaml@4.3.0` keys remain under `packages:`;
3. the snapshot dependency refs moved too (`js-yaml: 4.3.0`→`4.3.1`, `js-yaml: 3.15.0`→`3.15.1`) — a stale snapshot ref is the "override silently failed to apply" mode.

**The evidence entry is not inert** — running `evaluateLockedAdvisories` against a synthetic regressed lockfile flags both ranges:
```
GHSA-5p4m-2wfm-xmqj: js-yaml@3.15.0 is inside vulnerable range >= 3.0.0, < 3.15.1; first patched version is 3.15.1
GHSA-5p4m-2wfm-xmqj: js-yaml@4.3.0 is inside vulnerable range >= 4.0.0, < 4.3.1; first patched version is 4.3.1
```

The lockfile diff is confined to js-yaml: 10 insertions / 8 deletions, and the only non-`js-yaml` diff lines are the integrity hashes belonging to those same entries. No unrelated dependency churn.

## Residual advisories (deliberately not fixed)

`moderate=5, low=1` remain: `ajv` (`GHSA-2g4f-4pwh-qvx6`) and five `mermaid` advisories at 11.16.0. **These cannot fail the gate** — `BLOCKED_SEVERITIES = new Set(['high','critical'])` and `evaluateAudit` does `if (!BLOCKED_SEVERITIES.has(advisory.severity)) continue`. Bumping mermaid would touch the deck rendering path for zero gate benefit, so it is left for a deliberate dependency-maintenance change rather than folded into a CI unblock.
