### PR TITLE
:bug: fix(deck): reserve the click budget animated slides need to leave step 0

### DIFF
--- a/components/KubectlVerbDemo.vue
+++ b/components/KubectlVerbDemo.vue
@@ -2,6 +2,11 @@
 /**
  * Click-driven kubectl verb tour — command + sample output pairs.
  * Bind `:step="$clicks"`. Story: on-call triage for deployment `web`.
+ *
+ * step 0: `get`          — the surface view, is anything wrong at a glance?
+ * step 1: `describe`     — Events say *why* the Pod will not schedule
+ * step 2: `logs`         — app output from the last crash (OOMKilled, exit 137)
+ * step 3: `diff` + `apply` — preview, then declare: the safe-change sequence
  */
 const props = withDefaults(defineProps<{ step?: number }>(), { step: 0 })
 

--- a/components/PodStateDiagram.vue
+++ b/components/PodStateDiagram.vue
@@ -6,7 +6,10 @@ import { NEW_TAG, OLD_TAG } from './usePodReplace'
 /**
  * Click-driven cluster state, meant to sit next to a `magic-move` manifest:
  * bind `:step="$clicks"` so the diagram advances in lockstep with the code.
- * step 0: old pod Running · 1: new pod creating · 2: replaced
+ *
+ * step 0: old pod Running
+ * step 1: new pod creating alongside it
+ * step 2: replaced — the old pod is Terminating
  */
 const props = withDefaults(defineProps<{ step?: number }>(), { step: 0 })
 

--- a/components/ServiceSelectorMap.vue
+++ b/components/ServiceSelectorMap.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 /**
  * Styled selector → EndpointSlice → Pods diagram (replaces default mermaid on S07).
- * Bind `:step="$clicks"` for progressive reveal.
+ * Bind `:step="$clicks"` for progressive reveal — the slide must reserve a budget
+ * of 3 (`clicks: 3`), or the reveal never leaves step 0.
+ *
+ * step 0: cluster DNS only — the stable front door clients dial
+ * step 1: the Service lights up — ClusterIP + the `selector` label query
+ * step 2: the EndpointSlice lights up — matching Pod IPs, rewritten on every change
+ * step 3: the Pods themselves — the churning backends beneath the fixed front door
  */
 const props = withDefaults(
   defineProps<{

--- a/pages/S07-service/index.md
+++ b/pages/S07-service/index.md
@@ -89,6 +89,8 @@ ClusterIP only, which works identically in namespace and kind.
 -->
 
 ---
+clicks: 3
+---
 
 <div class="kw-slide-dense">
 

--- a/pages/S16-hpa/index.md
+++ b/pages/S16-hpa/index.md
@@ -273,7 +273,8 @@ dashed target line, the formula chip recomputes desired=4. (2) the herd grows to
 insight — the gauge eases back down, because the SAME total load divided over more Pods is less
 per Pod; autoscaling is negative feedback finding equilibrium. (3) it settles where per-Pod CPU ==
 target. (4) load disappears, the gauge drops, but the herd does NOT immediately shrink — it holds
-for the scaleDown stabilization window (default 300s) before returning to min. That asymmetry is
+for the scaleDown stabilization window (default 300s). (5) the window elapses and it returns to
+min — the click the budget was missing, so pause on it. That asymmetry is
 the next slide: scale up fast, scale down slow. This is the lab beat 3 (why did scale-down lag?).
 -->
 

--- a/pages/S16-hpa/index.md
+++ b/pages/S16-hpa/index.md
@@ -245,6 +245,8 @@ teaching view; the lab ships the full block-style files plus the metrics-server 
 -->
 
 ---
+clicks: 5
+---
 
 <span class="kw-kicker">The control loop, made physical · load drives the herd</span>
 

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -1,9 +1,11 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { parse as parseDeck } from '@slidev/parser/fs'
 
 import {
   DEFAULT_GITOPS,
@@ -838,5 +840,213 @@ describe('generate-decks --gitops parsing (fail closed)', () => {
     const result = runGenerateDecks(['--check', '--gitpos', 'flux'])
     assert.equal(result.status, 1, `expected exit 1, got ${result.status}\n${result.stderr}`)
     assert.match(result.stderr, /unknown option --gitpos/i)
+  })
+})
+
+/**
+ * US-FIX-ANIM-CLICKS — a bound animation only runs if its slide reserves clicks.
+ *
+ * Slidev derives a slide's click total from `clicksTotalOverrides ?? max(registered
+ * clicks)` (@slidev/client `composables/useClicks.ts`), so `clicks:` in frontmatter is
+ * an OVERRIDE, not a floor, and in-body `v-click` / `v-clicks` / `magic-move` elements
+ * reserve a budget on their own. A slide that binds `:step="$clicks"` but reserves
+ * fewer clicks than the bound component documents renders frozen at the last reachable
+ * step — `slidev build` cannot catch this, because the deck still parses.
+ *
+ * `registeredClicks` mirrors Slidev's runtime accounting. It was validated against 21
+ * live measurements (drive the dev server, press ArrowRight until the slide number
+ * changes, count the presses) and reproduced every measured total exactly.
+ */
+
+/** Click budget a slide body reserves, mirroring Slidev's runtime accounting. */
+export function registeredClicks(content) {
+  let cursor = 0
+  let max = 0
+  let fence = null
+  let magic = null
+  let vclicks = null
+
+  const bump = (n) => {
+    cursor = Math.max(cursor, n)
+    max = Math.max(max, n)
+  }
+
+  for (const raw of content.split('\n')) {
+    const line = raw.replace(/<!--[\s\S]*?-->/g, '')
+
+    // `md magic-move` container (4+ backticks): N inner frames reserve N-1 clicks.
+    const magicOpen = line.match(/^\s*(`{4,})\s*md\s+magic-move/)
+    if (!magic && magicOpen) {
+      magic = { marker: magicOpen[1], fences: 0 }
+      continue
+    }
+    if (magic) {
+      if (line.trim() === magic.marker) {
+        bump(cursor + Math.max(0, magic.fences / 2 - 1))
+        magic = null
+      } else if (/^\s*```/.test(line)) {
+        magic.fences += 1
+      }
+      continue
+    }
+
+    // Nothing inside a plain code fence registers a click.
+    const fenceMark = line.match(/^\s*(`{3,}|~{3,})/)
+    if (fence) {
+      if (fenceMark && line.trim().startsWith(fence)) fence = null
+      continue
+    }
+    if (fenceMark) {
+      fence = fenceMark[1]
+      continue
+    }
+
+    // <v-clicks [at="N"]> … </v-clicks> — one click per top-level list item.
+    if (vclicks) {
+      if (/<\/v-clicks>/.test(line)) {
+        const start = vclicks.start ?? cursor + 1
+        if (vclicks.items > 0) bump(start + vclicks.items - 1)
+        vclicks = null
+      } else if (/^[-*+]\s+\S/.test(line)) {
+        vclicks.items += 1
+      }
+      continue
+    }
+    const vclicksOpen = line.match(/<v-clicks(\s[^>]*)?>/)
+    if (vclicksOpen) {
+      const at = (vclicksOpen[1] || '').match(/\bat="(\d+)"/)
+      vclicks = { start: at ? Number(at[1]) : null, items: 0 }
+      continue
+    }
+
+    if (/<\/v-click>/.test(line)) continue
+
+    const explicit = line.match(/\bv-click="(\d+)"/)
+    if (explicit) {
+      bump(Number(explicit[1]))
+      continue
+    }
+    const atForm = line.match(/<v-click\s+at="(\d+)"/)
+    if (atForm) {
+      bump(Number(atForm[1]))
+      continue
+    }
+    if (/\bv-after\b/.test(line)) continue
+    if (/\bv-click\b/.test(line)) bump(cursor + 1)
+  }
+
+  return max
+}
+
+/** Effective click total Slidev will use for a slide. */
+export function slideClickBudget(slide) {
+  const override = slide.frontmatter?.clicks
+  return typeof override === 'number' ? override : registeredClicks(slide.content)
+}
+
+/** Highest `step N:` a component's header comment documents, or null if undocumented. */
+export function documentedMaxStep(repoRoot, component) {
+  const file = join(repoRoot, 'components', `${component}.vue`)
+  if (!existsSync(file)) return null
+  const header = readFileSync(file, 'utf8').match(/\/\*\*[\s\S]*?\*\//)
+  if (!header) return null
+  const steps = [...header[0].matchAll(/^\s*\*\s*step\s+(\d+)\s*:/gim)].map((m) => Number(m[1]))
+  return steps.length ? Math.max(...steps) : null
+}
+
+/** Section-library files plus the standalone galleries (generated roots only import). */
+function clickableDeckFiles(repoRoot) {
+  return readdirSync(join(repoRoot, 'pages'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join('pages', entry.name, 'index.md'))
+    .concat(['slides-templates.md', 'slides-showcase.md'])
+    .filter((rel) => existsSync(join(repoRoot, rel)))
+}
+
+/** Every slide that binds `:step="$clicks"`, with the budget it actually reserves. */
+async function collectClickBoundSlides(repoRoot) {
+  const found = []
+  for (const rel of clickableDeckFiles(repoRoot)) {
+    const abs = join(repoRoot, rel)
+    const deck = await parseDeck(readFileSync(abs, 'utf8'), abs)
+    for (const slide of deck.slides) {
+      for (const match of slide.content.matchAll(/<([A-Z][A-Za-z0-9]*)[^>]*:step="\$clicks"/g)) {
+        found.push({
+          slide: rel,
+          line: slide.start + 1,
+          heading: (slide.content.match(/^#\s+(.*)$/m) || [])[1] || '(untitled)',
+          component: match[1],
+          budget: slideClickBudget(slide),
+          declared: slide.frontmatter?.clicks ?? null,
+        })
+      }
+    }
+  }
+  return found
+}
+
+describe('animated component click budgets (US-FIX-ANIM-CLICKS)', () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+  it('discovers the deck\'s animated slides (guards the collector against matching nothing)', async () => {
+    const bound = await collectClickBoundSlides(repoRoot)
+    assert.ok(
+      bound.length >= 20,
+      `expected the deck's :step="$clicks" bindings to be discovered, found ${bound.length}`,
+    )
+  })
+
+  it('every component bound with :step="$clicks" documents its step contract', async () => {
+    const bound = await collectClickBoundSlides(repoRoot)
+    const undocumented = [...new Set(bound.map((b) => b.component))]
+      .filter((component) => documentedMaxStep(repoRoot, component) === null)
+      .sort()
+    assert.deepEqual(
+      undocumented,
+      [],
+      'each components/<name>.vue header comment must enumerate its "step N:" beats — ' +
+        `that comment is the contract a slide's click budget has to cover: ${undocumented.join(', ')}`,
+    )
+  })
+
+  it('every slide binding :step="$clicks" reserves a budget >= the component max step', async () => {
+    const bound = await collectClickBoundSlides(repoRoot)
+    const starved = bound
+      .map((b) => ({ ...b, maxStep: documentedMaxStep(repoRoot, b.component) }))
+      .filter((b) => b.maxStep !== null && b.budget < b.maxStep)
+      .map(
+        (b) =>
+          `${b.slide}:${b.line} "${b.heading}" — <${b.component}> documents steps 0..${b.maxStep} ` +
+          `but the slide reserves only ${b.budget} click(s), so it freezes at step ${b.budget}. ` +
+          `Missing budget: ${b.maxStep - b.budget} (add "clicks: ${b.maxStep}" to the slide frontmatter).`,
+      )
+    assert.deepEqual(
+      starved,
+      [],
+      `slides whose animation cannot reach its last documented step:\n  ${starved.join('\n  ')}`,
+    )
+  })
+
+  it('an explicit clicks: override never shrinks a budget the slide body already reserves', async () => {
+    const shrunk = []
+    for (const rel of clickableDeckFiles(repoRoot)) {
+      const abs = join(repoRoot, rel)
+      const deck = await parseDeck(readFileSync(abs, 'utf8'), abs)
+      for (const slide of deck.slides) {
+        const declared = slide.frontmatter?.clicks
+        if (typeof declared !== 'number') continue
+        const inBody = registeredClicks(slide.content)
+        if (declared < inBody) {
+          shrunk.push(
+            `${rel}:${slide.start + 1} declares "clicks: ${declared}" but its body reserves ${inBody}`,
+          )
+        }
+      }
+    }
+    assert.deepEqual(
+      shrunk,
+      [],
+      `clicks: is an override, not a floor — these slides lose steps:\n  ${shrunk.join('\n  ')}`,
+    )
   })
 })

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -34,6 +34,33 @@ import {
   selectSections,
 } from './deck-selector.mjs'
 
+/**
+ * Non-regex HTML-comment strip (indexOf walk). A single-pass regex replace such as
+ * `/<!--[\s\S]*?-->/g` is flagged by CodeQL as incomplete multi-character
+ * sanitization (js/incomplete-multi-character-sanitization), because the replacement
+ * can reassemble a `<!--` from the surrounding text. Walking with indexOf cannot.
+ *
+ * An unterminated `<!--` drops everything after it: in this deck's markdown an
+ * unclosed comment means the rest of the file is speaker notes, not visible content.
+ */
+export function stripHtmlComments(markdown) {
+  let visible = ''
+  let cursor = 0
+  while (cursor < markdown.length) {
+    const open = markdown.indexOf('<!--', cursor)
+    if (open < 0) {
+      visible += markdown.slice(cursor)
+      break
+    }
+    visible += markdown.slice(cursor, open)
+    const close = markdown.indexOf('-->', open + '<!--'.length)
+    if (close < 0)
+      break
+    cursor = close + '-->'.length
+  }
+  return visible
+}
+
 const section = (id, overrides = {}) => ({
   id,
   slug: `topic-${id.toLowerCase()}`,
@@ -728,26 +755,6 @@ describe('S21 GitOps Flux section variant (US-GITOPS-CHOICE-B)', () => {
     assert.match(flux, /labs\/day-3\/21-gitops-flux\.md/)
   })
 
-  // Non-regex HTML-comment strip (indexOf walk): a single-pass regex replace is
-  // flagged by CodeQL as incomplete multi-character sanitization.
-  function stripHtmlComments(markdown) {
-    let visible = ''
-    let cursor = 0
-    while (cursor < markdown.length) {
-      const open = markdown.indexOf('<!--', cursor)
-      if (open < 0) {
-        visible += markdown.slice(cursor)
-        break
-      }
-      visible += markdown.slice(cursor, open)
-      const close = markdown.indexOf('-->', open + '<!--'.length)
-      if (close < 0)
-        break
-      cursor = close + '-->'.length
-    }
-    return visible
-  }
-
   it('locks each claimed on-slide CLI verb into learner-visible content', () => {
     const flux = readFileSync(fluxPath, 'utf8')
     const visible = stripHtmlComments(flux)
@@ -871,9 +878,8 @@ export function registeredClicks(content) {
     max = Math.max(max, n)
   }
 
-  for (const raw of content.split('\n')) {
-    const line = raw.replace(/<!--[\s\S]*?-->/g, '')
-
+  // Speaker notes are HTML comments and reserve nothing — strip them before counting.
+  for (const line of stripHtmlComments(content).split('\n')) {
     // `md magic-move` container (4+ backticks): N inner frames reserve N-1 clicks.
     const magicOpen = line.match(/^\s*(`{4,})\s*md\s+magic-move/)
     if (!magic && magicOpen) {


### PR DESCRIPTION
## What

Animated teaching components bind `:step="$clicks"`, but a Slidev slide only advances
`$clicks` as far as the click budget it reserves. Two slides reserved too few, so their
animation rendered frozen — `slidev build` cannot catch this, because the deck still parses.

## The defect, verified

Slidev derives a slide's click total from `clicksTotalOverrides ?? max(registered clicks)`
(`@slidev/client/composables/useClicks.ts`). So `clicks:` frontmatter is an **override, not a
floor**, and in-body `v-click` / `v-clicks` / `magic-move` elements reserve a budget on their own.

I measured the real budget of all 21 `:step="$clicks"` slides by driving the dev server and
pressing ArrowRight until the slide number changed. Two were starved:

| Slide | Component | Documented steps | Budget reserved | Result |
| --- | --- | --- | --- | --- |
| `pages/S07-service/index.md` — "A Service is a selector" | `ServiceSelectorMap` | 0..3 | **0** | permanently static |
| `pages/S16-hpa/index.md` — "Watch the gauge move the count" | `HpaScaling` | 0..5 | **4** | never reached the final beat |

There are 22 `:step="$clicks"` bindings in `pages/` + `slides-templates.md`; the other 20 already
reserve enough via `v-clicks` / `magic-move` and are untouched. Blanket-adding `clicks:` to them
would have *shrunk* four (S14, S17, S25, S26 register 3–4 clicks in-body), because the frontmatter
key overrides rather than raises.

21 of the 22 were measured live. `pages/S21-gitops-flux/index.md` is the non-default GitOps variant
and is not in `slides.md`, so it was verified statically only — same shape as the S21/S22
`ReconcileLoop` slides that *were* measured (3 in-body clicks, steps 0..3).

## Changes

- `clicks: 3` on the S07 selector-map slide; `clicks: 5` on the S16 HPA slide.
- Step contracts documented for `ServiceSelectorMap` and `KubectlVerbDemo` (previously absent) and
  reformatted for `PodStateDiagram` (three steps were on one line).
- Regression test in `scripts/deck.test.mjs`: for every `:step="$clicks"` binding, compare the
  budget the slide reserves against the max step its component documents, and fail naming the slide
  path **and** the missing budget. A companion test rejects any `clicks:` value below what the slide
  body already reserves, so the override can never silently remove a step.

Net-zero on content: no new slides, no new prose, `sectionTimings` untouched.

## Evidence

**Paper-gate** — deleting `clicks: 3` from the already-correct S05 and S11 slides turned the suite
red naming both (`S05 … reserves only 2 click(s)`, `S11 … reserves only 0 click(s)`); both restored
byte-for-byte.

**Estimator validated** — the static budget model reproduced all 21 live measurements exactly
(21/21), including the `magic-move` slide in `slides-templates.md`.

**Visual proof** — `--with-clicks` does not expand frame counts in this repo, so states were
captured from the running deck:

| Slide | Before | After |
| --- | --- | --- |
| S07 selector map | 0 clicks, click-0 and click-3 screenshots **identical** | 3 clicks, start/end **differ** — DNS → Service → EndpointSlice → Pods light up in turn, caption advances |
| S16 HPA | 4 clicks, ends on `REPLICAS 4 · holding · scaleDown 300s` | 5 clicks, ends on `REPLICAS 2`, paying off the existing "then shrink to min" bullet |

**Out of scope, needs a follow-up story** — S07's `ServiceRouting` beat where one Pod goes NotReady
*is* reachable (budget 2 = the component's `removeAt` 2; the click-2 render shows `web-6f8c-lm4tt`
NotReady and dropped from the slice). But the component fuses "goes NotReady" and "traffic reroutes"
into a single step 2, so there is no distinct intermediate beat. Splitting them would change
`ServiceRouting`'s step contract and need a new bullet on both S07 and S14 — new prose, outside this
lane's net-zero remit.

## Notes for the reviewer

- **Exported artifacts are unchanged by this PR.** Directly measured: PNG export of slides
  67/124/153 is byte-identical before and after. The PDFs were *not* diffed directly (only the
  post-fix ones were produced), but `slidev export` drives the same print-mode path for both
  formats, so they are expected identical too.
  The corollary matters more than the diff: **every** animated slide already exports frozen at
  step 0 — with or without a click budget — because `--with-clicks` does not expand frame counts
  here. That is pre-existing and untouched by this lane. The fix affects the live-presented deck only.
- **`node scripts/dependency-audit.mjs` now exits 0.** It was red before the rebase, from js-yaml
  advisory GHSA-5p4m-2wfm-xmqj; #37 landed the locked-advisory evidence on `main` and this branch is
  now rebased onto `bb38eb0`. Re-run and confirmed: `critical=0, high=0`, "no unexcepted high or
  critical advisories".

- **CodeQL fix, second push.** The first push used `/<!--[\s\S]*?-->/g` in the estimator to drop
  speaker notes, which raised a new high-severity
  `js/incomplete-multi-character-sanitization` alert. This repo had already solved that rule in
  `7296956` with a non-regex `indexOf` walk, but the helper was scoped inside the *S21 GitOps Flux*
  describe block. It is now hoisted to module scope and shared — **one implementation, three call
  sites** (the two S21 assertions unchanged, plus the estimator). No second copy.

  The estimator now strips comments across the whole slide once rather than per line, so multi-line
  speaker notes are excluded from click counting instead of only same-line ones — strictly more
  correct, and it hardens the count against a note that merely *mentions* `v-click`.
  **Confirmed behaviour-preserving:** body and effective click budgets are byte-identical across all
  310 slides in the section library (full dump diffed before vs after, zero changes). The paper-gate
  was re-run *after* the refactor: deleting `clicks: 3` from S07 still turns the suite red naming
  that slide.
