### PR TITLE
:memo: docs(readme): drop shipped GitOps choice from the roadmap-future row

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ telemetry.
 | **Quizzes** | [`quiz/README.md`](./quiz/README.md) (portable prototype; FOSS live host still open) |
 | **Run slides locally** | [`docs/run-slides.md`](./docs/run-slides.md) (Node.js + pnpm) |
 | **Known limitations** | [`docs/beta-limitations.md`](./docs/beta-limitations.md) (S24 stub; add-on smoke backlog) |
-| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, GitOps choice, OpenTelemetry — no dates) |
+| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, OpenTelemetry — no dates) |
 
 ![Animated tour of the workshop deck — real slides stepping through their click animations](docs/images/deck-showcase.gif)
 


### PR DESCRIPTION
## Defect

`README.md:39` — the front-door **Roadmap** row grouped `GitOps choice` with genuinely-future items under "no dates":

```
| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, GitOps choice, OpenTelemetry — no dates) |
```

The GitOps work has **fully shipped to `main`**. Verified against the tree at `7895081`:

- `pages/S21-gitops/` and `pages/S21-gitops-flux/` both exist
- `labs/day-3/21-gitops-flux.md` (10.5K) and `.solution.md` (15.8K) exist
- `scripts/deck-manifest.mjs:60-70` — `GITOPS_TOOLS = ['argocd', 'flux']`, `DEFAULT_GITOPS = 'argocd'`, both variant sources wired
- `docs/run-slides.md:64-70` documents the `--gitops argocd|flux` facilitator flag

Same defect class as the roadmap-honesty P1 in #36: public-facing docs describing delivered work as future. The README is the project's front door.

## Fix

One-line deletion of the stale entry:

```diff
-| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, GitOps choice, OpenTelemetry — no dates) |
+| **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, OpenTelemetry — no dates) |
```

**Why deletion, not "shipped":** `docs/roadmap.md:33` still reads `### GitOps tool choice — planned`, and that file is owned by #36. A "shipped" claim here would contradict the page this row links to until #36 merges — in a merge order this lane does not control. Deletion is true under both orders and introduces no new status vocabulary. The parenthetical is a summary, not an exhaustive index.

No dates, no commitments, and **no validation claim** — shipping is a delivery fact, not a statement that the GitOps content has been smoke-tested or rehearsed.

## Not stale (checked, unchanged)

- `README.md:36` Quizzes — "portable prototype; FOSS live host still open" matches `quiz/README.md` (US-QUIZ-1 spike, not embedded in Slidev). Accurate.
- `README.md:38` Known limitations — "S24 stub; add-on smoke backlog" matches `docs/beta-limitations.md:7` and `:11`. Accurate.
- `README.md:50` ("Helm, GitOps, and operators") and `:65` ("deliver with Helm and GitOps") already read as delivery claims, which are now correct. No adjacent stale wording.

## Cross-lane signal

`docs/roadmap.md:33` `GitOps tool choice — planned` **is stale** — deliberately untouched here, owned by #36 (`docs/release-prep-honesty`).

## Gates

| Gate | Result |
| --- | --- |
| `pnpm lint` | pass — markdownlint-cli2, 55 files, 0 issues |
| `pnpm link-check` | pass — 14 docs, no placeholders, all internal links and anchors resolve |
| `pnpm test:pages` | pass — 15/15, incl. all `scripts/readme-front-door.test.mjs` assertions |

`node scripts/dependency-audit.mjs` is expected-red on `main` (js-yaml GHSA-5p4m-2wfm-xmqj) and is fixed by #37 — out of scope here, untouched.

## Scope

`README.md` only, one line.
