### PR TITLE
:memo: docs: prepare v0.5.0 — bump download pins and record markdownlint gate coverage

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -288,4 +288,17 @@ and `scripts/release-tag-guard.sh`).
   available.
 - Verify every lab runs from a clean namespace **and** a clean kind cluster, and that
   cleanup returns the environment to a known state.
+- `pnpm lint` (markdownlint-cli2) is scoped to the single glob `labs/**/*.md` in
+  `.markdownlint-cli2.jsonc`, so a green lint is **no** evidence about `README.md`,
+  `docs/**`, `slides*.md`, or `pages/**` (`labs/README.md` is covered; the root
+  `README.md` is not). `pnpm link-check` covers a different set again — an explicit
+  14-file list in `scripts/link-check.mjs`, links and anchors only, excluding
+  `docs/decisions/**`, `slides*.md` and `pages/**`. Outside those two scopes there is
+  no **markdownlint or link/anchor** gate, but targeted *content* gates do exist:
+  `pnpm decks:check` (drift for the six decks in `generatedDecks` only — hand-authored
+  `slides-templates.md`/`slides-showcase.md` get only `test:deck`'s click-budget check —
+  plus each section's `pages/<id>-<slug>/index.md`, `README.md` and the syllabus/
+  facilitator/validation-matrix/labs-README docs), `pnpm test:pages` (`README.md`,
+  `docs/index.md`, `docs/release.md`, `mkdocs.yml`) and `pnpm test:labs` (lab contract;
+  the numbered ADRs and index in `docs/decisions/`). Check the gate, not the glob.
 - Keep planning docs in `agent-context/` concise and current as decisions change.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -40,12 +40,12 @@ Typical artifact names (tag substituted for `<tag>`):
 | `kubernetes-workshop-3day-<tag>.pdf` | Compatibility three-day cut |
 | `kubernetes-workshop-site-<tag>.zip` | Offline HTML bundle |
 
-Example pins from **`v0.4.0`**:
+Example pins from **`v0.5.0`**:
 
-- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.4.0/kubernetes-workshop-day-1-v0.4.0.pdf)
-- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.4.0/kubernetes-workshop-day-2-v0.4.0.pdf)
-- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.4.0/kubernetes-workshop-day-3-v0.4.0.pdf)
-- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.4.0)
+- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-1-v0.5.0.pdf)
+- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-2-v0.5.0.pdf)
+- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-3-v0.5.0.pdf)
+- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.5.0)
 
 Pre-release tags still prepend [known limitations](./beta-limitations.md) to the release
 notes body. How tags are cut: [release.md](./release.md).


### PR DESCRIPTION
Prepares the tree for the `v0.5.0` tag. Does **not** tag — the coordinator does that after this merges.

Rebased onto `7406c09`; merges cleanly.

## Task 1 — bump download pins to `v0.5.0` (`docs/downloads.md`)

`docs/downloads.md` is the only manual version surface in the repo (version otherwise lives in the git tag alone). All 8 `v0.4.0` occurrences in the "Example pins" block were bumped — 1 prose line plus 4 link lines, three of which carry **two** occurrences each (URL path segment *and* filename).

Untouched by design:

- the `<tag>` placeholder table (deliberately generic),
- the self-updating `/releases` and `/releases/latest` links,
- `docs/release.md:41`, which uses `v0.4.0` as illustrative prose, not a URL — still true.

`grep -c 'v0\.4\.0' docs/downloads.md` is now **0**; `v0.5.0` appears **8** times. Matches the pattern from `19623be` (`docs-pin-beta2`), verified against that commit's diff. **Unchanged since the first review round.**

**Expected:** the new URLs 404 until the tag is pushed and the Release workflow publishes assets. That is intentional and is the repo's precedent.

## Task 2 — record gate coverage in `AGENT.md`

Three lanes independently re-derived the markdownlint scope in one session, so it is now written down — as a *map* of which gate covers which paths.

Every claim was read out of the source. Three review rounds each surfaced a claim that would have been false; verifying rather than trusting caught all three:

- **markdownlint** — `.markdownlint-cli2.jsonc` declares one glob, `labs/**/*.md`, no `ignores`; `package.json` runs bare `markdownlint-cli2`; CI job "Lint labs (markdown)" runs `pnpm lint`. The run prints `Finding: labs/**/*.md`.
- **link-check** — `scripts/link-check.mjs` `DOCS` is an explicit **14-file list**, not a `docs/**` glob (run prints "14 docs"). `docs/decisions/**`, `slides*.md`, `pages/**` are absent.
- **decks:check** — `generate-decks.mjs:66-67` renders `generatedDecks` and diffs it against disk; `deck-manifest.mjs:50-57` shows that array holds exactly **six** files. The repo has **eight** `slides*.md` — `slides-templates.md` *and* `slides-showcase.md` are hand-authored and never drift-checked. `validateManifest` (`deck-manifest.mjs:133`) existence-checks each section's `pages/<Sxx>-<slug>/index.md`; `:137-145` flags authored `pages/S##-*` dirs missing from the manifest; `validateDocumentationTruth` asserts manifest truth in `README.md`, `docs/syllabus.md`, `docs/facilitator-guide.md`, `docs/validation-matrix.md`, `labs/README.md`.
- **test:deck** — `deck.test.mjs:964-969` (`clickableDeckFiles`) is the only place the two excluded decks appear, and it feeds solely the "animated component click budgets" suite (`:994-1050`). So they get a **click-budget check only**, not general validation — the note says exactly that.
- **test:pages** — `readme-front-door.test.mjs` reads `README.md`, `docs/index.md`, `docs/release.md`, `LICENSE`, `mkdocs.yml`; `pages-site.test.mjs` existence-checks `docs/{index,run-slides,downloads,roadmap}.md`.
- **test:labs** — `lab-contract.mjs:10-40` is an explicit per-lab list; `:479-503` reads `docs/decisions/README.md` and `readdirSync('docs/decisions')` filtered to `/^\d{4}-.+\.md$/`, asserting ADR status hygiene. So `docs/decisions/**` is *not* ungated.

One bullet under the existing `## Validation` section; no restructuring, and no net line growth versus the previous round.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm lint` | pass — `Finding: labs/**/*.md`, 55 files, 0 issues |
| `pnpm link-check` | pass — 14 docs, all internal links and anchors resolve |
| `pnpm test:pages` | pass — 15/15 |
| `pnpm decks:check` | pass — generated decks current, 6 entries / 28 sections |
| `pnpm test:deck` | pass (extra) — 53/53, run because the note now cites it |
| `node scripts/dependency-audit.mjs` | pass (exit 0) — critical=0, high=0 |

`pnpm link-check` validates internal links only, so it cannot catch a malformed external release URL; the bumped URLs were diffed by eye against the v0.4.0 originals — identical shape, version only.
