### PR TITLE
:memo: docs: pin v0.5.1 release download links

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -40,12 +40,12 @@ Typical artifact names (tag substituted for `<tag>`):
 | `kubernetes-workshop-3day-<tag>.pdf` | Compatibility three-day cut |
 | `kubernetes-workshop-site-<tag>.zip` | Offline HTML bundle |
 
-Example pins from **`v0.5.0`**:
+Example pins from **`v0.5.1`**:
 
-- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-1-v0.5.0.pdf)
-- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-2-v0.5.0.pdf)
-- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.0/kubernetes-workshop-day-3-v0.5.0.pdf)
-- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.5.0)
+- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-1-v0.5.1.pdf)
+- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-2-v0.5.1.pdf)
+- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-3-v0.5.1.pdf)
+- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.5.1)
 
 Pre-release tags still prepend [known limitations](./beta-limitations.md) to the release
 notes body. How tags are cut: [release.md](./release.md).


### PR DESCRIPTION
Release prep for `v0.5.1`, following the precedent of `79bd54e` (the v0.5.0 pin bump).

`docs/downloads.md` carries example asset pins for the current tag. Bumps the four
`v0.5.0` links to `v0.5.1` so they name the assets the next release publishes.

The four pinned names are all in the release workflow's artifact set
(`day-{1,2,3}`, plus the tag page for the full / 3-day PDFs and site zip).

## Gates

| Gate | Result |
| --- | --- |
| `pnpm link-check` | OK — 14 docs (`docs/downloads.md` is in the list) |
| `pnpm lint` | 0 issues (55 files) |

Merge before pushing the `v0.5.1` tag.