### PR TITLE
📝 docs: close two P3s shipped in v0.5.0 (matrix wording, S16 speaker note)

### DIFF
--- a/docs/validation-matrix.md
+++ b/docs/validation-matrix.md
@@ -170,7 +170,7 @@ resolved history. Both of those rows stay `unrun` until the US-BETA-6 rehearsal 
 US-ENV-4 smoke re-runs them against the new stack. Elsewhere in the matrix exactly one
 row is promoted past the `unrun`/`server-dry-run` band — the Flux S21 variant's
 maintainer-recorded `kind-smoke`, per the honesty rule above — and every other row
-remains `unrun`/`server-dry-run`, with the unauthored S24 stub `deferred`.
+remains `unrun`/`server-dry-run`, apart from the unauthored S24 stub, which stays `deferred`.
 
 ## What this matrix feeds
 

--- a/pages/S16-hpa/index.md
+++ b/pages/S16-hpa/index.md
@@ -274,7 +274,7 @@ insight — the gauge eases back down, because the SAME total load divided over 
 per Pod; autoscaling is negative feedback finding equilibrium. (3) it settles where per-Pod CPU ==
 target. (4) load disappears, the gauge drops, but the herd does NOT immediately shrink — it holds
 for the scaleDown stabilization window (default 300s). (5) the window elapses and it returns to
-min — the click the budget was missing, so pause on it. That asymmetry is
+min — pause here so the delayed shrink registers. That asymmetry is
 the next slide: scale up fast, scale down slow. This is the lab beat 3 (why did scale-down lag?).
 -->
 


### PR DESCRIPTION
## What

Closes the two small P3 follow-ups registered on the operator board after v0.5.0:

1. **`docs/validation-matrix.md`** — the closing sentence of the US-NGX note said every other row remains `unrun`/`server-dry-run`, *with* the unauthored S24 stub `deferred`. S24's State cell is `deferred`, so it is an exception to that band, not a member of it. The sentence now reads "apart from the unauthored S24 stub, which stays `deferred`" — exactly matching the State cells (sole promotion: Flux S21 `kind-smoke`).
2. **`pages/S16-hpa/index.md`** — the click-5 speaker note narrated a repo-internal defect ("the click the budget was missing, so pause on it"). Replaced with the facilitator-facing teaching beat ("pause here so the delayed shrink registers"). HTML-comment-only; nothing on-slide changes.

## Gates

- `pnpm decks:check` — pass
- `pnpm test:deck` — pass (53/53; confirms S16 click budget/step contract unchanged)
- `pnpm build` — pass
- `pnpm lint` (markdownlint) — pass (0 issues / 55 files)
- `pnpm link-check` — pass (14 docs)
- `node scripts/dependency-audit.mjs` — **expected-red** (exit 1: 3 high advisories, image-size x2 + nanoid, owned by lane `fix/dep-advisories`)