### PR TITLE
:lock: fix(deps): clear the post-v0.5.1 high advisories (nanoid, image-size)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   js-yaml@>=5.0.0 <6.0.0: 5.2.3
   js-yaml@>=4.0.0 <5.0.0: 4.3.1
   js-yaml@>=3.0.0 <4.0.0: 3.15.1
+  nanoid@>=3.0.0 <4.0.0: 3.3.17
   dompurify: 3.4.13
   '@hono/node-server': 2.1.0
 
@@ -2475,8 +2476,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6223,7 +6224,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanotar@0.3.0: {}
 
@@ -6397,7 +6398,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,11 @@ overrides:
   # than dragging Slidev's YAML parser across a major-version boundary.
   "js-yaml@>=4.0.0 <5.0.0": 4.3.1
   "js-yaml@>=3.0.0 <4.0.0": 3.15.1
+  # GHSA-2v37-7h3g-55p8: nanoid custom generators can loop indefinitely when
+  # size is zero. Patched separately per line (3.x at 3.3.17, 5.x at 5.1.6);
+  # postcss pulls the 3.x line transitively, so pin that range to its first
+  # patched version without dragging any consumer across a major boundary.
+  "nanoid@>=3.0.0 <4.0.0": 3.3.17
   # monaco-editor / mermaid pull older DOMPurify; pin the patched line.
   dompurify: 3.4.13
   # Dependabot/GHSA collapses @hono/node-server to "<2.0.5" even though
@@ -33,4 +38,5 @@ overrides:
 # pnpm 11 minimumReleaseAge gate: allow this override pin through when fresh on the registry.
 minimumReleaseAgeExclude:
   - '@hono/node-server@2.1.0'
+  - 'nanoid@3.3.17'
 

--- a/scripts/dependency-audit.test.mjs
+++ b/scripts/dependency-audit.test.mjs
@@ -307,3 +307,12 @@ test('js-yaml override is bounded to the intended 5.x major', async () => {
   assert.match(workspace, /"js-yaml@>=5\.0\.0 <6\.0\.0": 5\.2\.3/)
   assert.doesNotMatch(workspace, /"js-yaml@>=5\.0\.0":/)
 })
+
+test('nanoid override is bounded to the intended 3.x major at its patched floor', async () => {
+  const root = path.resolve(import.meta.dirname, '..')
+  const workspace = await readFile(path.join(root, 'pnpm-workspace.yaml'), 'utf8')
+
+  assert.match(workspace, /"nanoid@>=3\.0\.0 <4\.0\.0": 3\.3\.17/)
+  assert.doesNotMatch(workspace, /"nanoid@>=3\.0\.0":/)
+  assert.doesNotMatch(workspace, /(^|\s)nanoid:/m)
+})

--- a/scripts/dependency-audit.test.mjs
+++ b/scripts/dependency-audit.test.mjs
@@ -308,6 +308,17 @@ test('js-yaml override is bounded to the intended 5.x major', async () => {
   assert.doesNotMatch(workspace, /"js-yaml@>=5\.0\.0":/)
 })
 
+test('js-yaml 3.x and 4.x overrides are bounded to their own patched floors', async () => {
+  const root = path.resolve(import.meta.dirname, '..')
+  const workspace = await readFile(path.join(root, 'pnpm-workspace.yaml'), 'utf8')
+
+  assert.match(workspace, /"js-yaml@>=3\.0\.0 <4\.0\.0": 3\.15\.1/)
+  assert.match(workspace, /"js-yaml@>=4\.0\.0 <5\.0\.0": 4\.3\.1/)
+  assert.doesNotMatch(workspace, /"js-yaml@>=3\.0\.0":/)
+  assert.doesNotMatch(workspace, /"js-yaml@>=4\.0\.0":/)
+  assert.doesNotMatch(workspace, /(^|\s)js-yaml:/m)
+})
+
 test('nanoid override is bounded to the intended 3.x major at its patched floor', async () => {
   const root = path.resolve(import.meta.dirname, '..')
   const workspace = await readFile(path.join(root, 'pnpm-workspace.yaml'), 'utf8')

--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -1,0 +1,16 @@
+# supply-chain
+
+Machine-checked supply-chain policy inputs for `scripts/dependency-audit.mjs`
+and related gates.
+
+- `dependency-advisories.json` — locked advisory evidence captured from the
+  GitHub Global Security Advisory API. `evaluateLockedAdvisories` iterates the
+  `advisories` **array**, so one advisory id may appear in **multiple entries**
+  when upstream patched each release line separately (e.g.
+  `GHSA-5p4m-2wfm-xmqj` for js-yaml 3.x and 4.x, `GHSA-2v37-7h3g-55p8` for
+  nanoid 3.x and 4/5.x). Record one entry per vulnerable range with that
+  range's own first patched version.
+- `dependency-audit.json` — audit policy. `exceptions` waive a high/critical
+  advisory only with a documented `reason`, an `owner`, and an ISO `expires`
+  date; the gate fails closed once the date passes.
+- `exceptions.json` — reviewed remote-input allowances for automation scripts.

--- a/supply-chain/dependency-advisories.json
+++ b/supply-chain/dependency-advisories.json
@@ -1,5 +1,5 @@
 {
-  "captured": "2026-08-07",
+  "captured": "2026-08-09",
   "source": "GitHub Global Security Advisory API",
   "advisories": [
     {
@@ -37,6 +37,24 @@
       "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
       "firstPatchedVersion": "4.3.1",
       "source": "https://github.com/advisories/GHSA-5p4m-2wfm-xmqj"
+    },
+    {
+      "id": "GHSA-2v37-7h3g-55p8",
+      "package": "nanoid",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": "< 3.3.17",
+      "firstPatchedVersion": "3.3.17",
+      "source": "https://github.com/advisories/GHSA-2v37-7h3g-55p8"
+    },
+    {
+      "id": "GHSA-2v37-7h3g-55p8",
+      "package": "nanoid",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.0, < 5.1.6",
+      "firstPatchedVersion": "5.1.6",
+      "source": "https://github.com/advisories/GHSA-2v37-7h3g-55p8"
     }
   ]
 }

--- a/supply-chain/dependency-audit.json
+++ b/supply-chain/dependency-audit.json
@@ -1,3 +1,16 @@
 {
-  "exceptions": []
+  "exceptions": [
+    {
+      "id": "GHSA-w3rx-r6r6-pgpr",
+      "reason": "image-size ICNS infinite-loop DoS. No patched release exists: the npm registry's latest image-size is 2.0.2, still inside the vulnerable range <= 2.0.2. The only dependency path is pptxgenjs (slidev PPTX export), pinned by upstream to image-size ^1.2.1, and the parser only ever sees this repository's curated slide assets, never attacker-supplied images. Re-check the registry for a patched release before expiry.",
+      "owner": "maintainers",
+      "expires": "2026-10-08"
+    },
+    {
+      "id": "GHSA-5p2g-fcmc-qvqq",
+      "reason": "image-size JXL/HEIF infinite-loop DoS. Same situation as GHSA-w3rx-r6r6-pgpr: no patched release exists on npm (latest 2.0.2 is inside <= 2.0.2), the sole path is pptxgenjs via slidev PPTX export, and inputs are repository-curated slide assets only. Re-check the registry for a patched release before expiry.",
+      "owner": "maintainers",
+      "expires": "2026-10-08"
+    }
+  ]
 }


### PR DESCRIPTION
## What

Three high advisories published after the v0.5.1 tag made `node scripts/dependency-audit.mjs` exit 1 (main's green CI tick is stale):

- **GHSA-2v37-7h3g-55p8** — nanoid: custom generators can loop indefinitely when size is zero. Lockfile had nanoid@3.3.16 (via postcss).
- **GHSA-w3rx-r6r6-pgpr** — image-size: ICNS parser infinite-loop DoS.
- **GHSA-5p2g-fcmc-qvqq** — image-size: JXL/HEIF parser infinite-loop DoS.

## Fix pattern

**nanoid** (patch exists) — same pattern as the js-yaml fix in #37: a bounded pnpm override in `pnpm-workspace.yaml` mapping the vulnerable line to its own first patched release (`nanoid@>=3.0.0 <4.0.0` → 3.3.17, no major-boundary jump), plus locked advisory evidence in `supply-chain/dependency-advisories.json` for **both** patched lines (3.x → 3.3.17 and 4/5.x → 5.1.6; two entries sharing one GHSA id, the js-yaml precedent). 3.3.17 is 6 days old, so it is listed in `minimumReleaseAgeExclude` like the earlier @hono/node-server pin.

**image-size** (no patch exists) — the npm registry's latest image-size is 2.0.2, still inside the vulnerable range `<= 2.0.2`; pnpm audit's "patched >=2.0.3" is the range complement, not a release. Sole dependency path is pptxgenjs ^1.2.1 (slidev PPTX export), latest pptxgenjs included, and the parsers only ever see repo-curated slide assets. Recorded as two documented **expiring exceptions** (2026-10-08) in `supply-chain/dependency-audit.json` — the gate's designed suppression-with-evidence mechanism; it fails closed when they expire, forcing a registry re-check. No advisory-evidence entry: the evidence schema honestly cannot represent an advisory with no patched floor.

## Also folded in

- **P2 (from #37 review):** `scripts/dependency-audit.test.mjs` now asserts the js-yaml 3.x→3.15.1 and 4.x→4.3.1 bounded overrides (previously only the 5.x bound was guarded), plus the new nanoid bound. Each assertion was proven non-vacuous (mutated the pin → red, restored → green).
- **P3:** `supply-chain/README.md` documents the one-advisory-id-per-vulnerable-range evidence convention.

## Gates (all green)

- `node scripts/dependency-audit.mjs` → exit 0 (critical=0, unexcepted high=0; raw pnpm-audit count still lists the two excepted image-size advisories)
- `node --test scripts/dependency-audit.test.mjs` → 23 pass / 0 fail
- `pnpm build` (incl. `decks:check`) → green
- `pnpm test:deck` → 63 pass / 0 fail (lockfile hoisting check)
- `pnpm lint`, `pnpm test:labs`, `pnpm test:pages`, `pnpm link-check` → green

Note: the intermediate nanoid commit still fails the audit gate on the pre-existing image-size advisories (inherited from main, strictly improved); the exception commit completes the green state.