### PR TITLE
✨ feat(supply-chain): enumerate active advisory exceptions in passing audit output

### DIFF
--- a/scripts/dependency-audit.mjs
+++ b/scripts/dependency-audit.mjs
@@ -68,20 +68,31 @@ export function evaluateAudit(report, policy, today = new Date().toISOString().s
     validExceptions.set(exception.id, exception)
   }
 
+  const waivedPackages = new Map()
   for (const advisory of Object.values(report.advisories ?? {})) {
     if (!BLOCKED_SEVERITIES.has(advisory.severity)) continue
     const id = advisory.github_advisory_id ?? String(advisory.id ?? 'unknown-advisory')
     if (!validExceptions.has(id)) {
       errors.push(`${id}: ${advisory.module_name} (${advisory.severity}) — ${advisory.title}`)
+    } else {
+      waivedPackages.set(id, advisory.module_name)
     }
   }
 
-  return {
-    ok: errors.length === 0,
-    message: errors.length === 0
-      ? 'Locked dependency audit passed: no unexcepted high or critical advisories.'
-      : errors.join('\n'),
-  }
+  if (errors.length > 0) return { ok: false, message: errors.join('\n') }
+
+  const exceptionLines = [...validExceptions.values()].map((exception) => {
+    const subject = waivedPackages.get(exception.id) ?? '(no matching advisory in this run)'
+    return `  ${exception.id}: ${subject} — expires ${exception.expires} — ${exception.reason}`
+  })
+  const message = exceptionLines.length === 0
+    ? 'Locked dependency audit passed: no unexcepted high or critical advisories.'
+    : [
+        'Locked dependency audit passed: no unexcepted high or critical advisories.',
+        `Active exceptions (${exceptionLines.length}):`,
+        ...exceptionLines,
+      ].join('\n')
+  return { ok: true, message }
 }
 
 function compareVersions(left, right) {

--- a/scripts/dependency-audit.test.mjs
+++ b/scripts/dependency-audit.test.mjs
@@ -37,6 +37,43 @@ test('accepts a documented unexpired advisory exception', () => {
   assert.equal(result.ok, true)
 })
 
+test('a passing run enumerates each active exception with id, package, expiry, and reason', () => {
+  const result = evaluateAudit(highAdvisory, {
+    exceptions: [{
+      id: 'GHSA-aaaa-bbbb-cccc',
+      reason: 'No reachable vulnerable path in the static deck build.',
+      owner: 'maintainers',
+      expires: '2026-08-31',
+    }],
+  }, '2026-08-03')
+
+  assert.equal(result.ok, true)
+  assert.match(result.message, /Active exceptions \(1\)/)
+  assert.match(result.message, /GHSA-aaaa-bbbb-cccc: example — expires 2026-08-31 — No reachable vulnerable path in the static deck build\./)
+})
+
+test('a passing run lists an active exception even when no current advisory matches it', () => {
+  const result = evaluateAudit({ advisories: {}, metadata: { vulnerabilities: {} } }, {
+    exceptions: [{
+      id: 'GHSA-aaaa-bbbb-cccc',
+      reason: 'Kept until the upstream fix lands.',
+      owner: 'maintainers',
+      expires: '2026-08-31',
+    }],
+  }, '2026-08-03')
+
+  assert.equal(result.ok, true)
+  assert.match(result.message, /Active exceptions \(1\)/)
+  assert.match(result.message, /GHSA-aaaa-bbbb-cccc: \(no matching advisory in this run\) — expires 2026-08-31 — Kept until the upstream fix lands\./)
+})
+
+test('a passing run without exceptions stays free of an exception section', () => {
+  const result = evaluateAudit({ advisories: {}, metadata: { vulnerabilities: {} } }, { exceptions: [] }, '2026-08-03')
+
+  assert.equal(result.ok, true)
+  assert.doesNotMatch(result.message, /Active exceptions/i)
+})
+
 test('fails an expired advisory exception', () => {
   const result = evaluateAudit(highAdvisory, {
     exceptions: [{


### PR DESCRIPTION
## What

Resolves F1 (P3) from the independent review of PR #44: a passing `scripts/dependency-audit.mjs` run printed only the raw count line (`high=2`) plus a generic "no unexcepted high or critical advisories" message, so an operator reading CI logs could not tell which advisories were waived without opening `supply-chain/dependency-audit.json`.

A passing run now appends an `Active exceptions (N):` block naming each valid exception — GHSA id, waived package (from the matched advisory's `module_name`), expiry date, and reason — right next to the green verdict. An exception with no matching advisory in the current run is still listed, flagged `(no matching advisory in this run)`. A pass with zero exceptions keeps the plain one-line message.

## What did NOT change

- No pass/fail semantics changed — output only. All failure paths (expired, malformed, unexcepted) emit exactly the messages they did before.
- Files touched: `scripts/dependency-audit.mjs`, `scripts/dependency-audit.test.mjs` only. No `supply-chain/README.md` change needed — the behavior is self-describing in the output.

## TDD / mutation evidence

- Wrote 3 tests first (enumeration with id+package+expiry+reason; unmatched-exception listing; no section when no exceptions): suite went 24 pass / 2 fail before the implementation.
- Mutation check: removing the enumeration (reverting the pass message to the plain string) turns the two enumeration tests red; restoring turns the suite green (26/26).

## Gates

- `node scripts/dependency-audit.mjs` — exit 0, both GHSA-w3rx-r6r6-pgpr and GHSA-5p2g-fcmc-qvqq enumerated with package/expiry/reason
- `node --test scripts/dependency-audit.test.mjs` — 26/26 pass
- `pnpm build` — green
- `pnpm test:deck` — 57/57 pass (lockfile untouched)