### PR TITLE
✨ feat(deck): split the NotReady beat from the reroute in ServiceRouting

### DIFF
--- a/components/ServiceRouting.vue
+++ b/components/ServiceRouting.vue
@@ -4,16 +4,20 @@ import { computed } from 'vue'
 /**
  * Click-driven service routing — the shared US-X3 animation.
  * Bind `:step="$clicks"`. Shows the wiring a Service actually is:
- * selector → EndpointSlice → Pods, then the readiness variant that removes a
- * Pod from the slice without deleting it (the bridge S14 reuses).
+ * selector → EndpointSlice → Pods, then the readiness variant that first marks a
+ * Pod NotReady and only then removes it from the slice, without deleting it
+ * (the bridge S14 reuses).
  *
  * Pure Vue + CSS on the kw-* vocabulary (ADR 0001); every fixed `step` is a
  * meaningful static state for export. Parameterized (serviceName / selector /
  * pods / removeAt) so S14 can reuse it for the readiness-probe story.
+ * `removeAt` is the step at which the endpoint leaves the slice; the readiness
+ * probe fails one step earlier, at `removeAt - 1`.
  *
  * step 0: Service + selector, all Pods in the slice (steady state)
  * step 1: a request fans out across all endpoints (load-balanced)
- * step 2: one Pod goes NotReady → leaves the slice → traffic reroutes to the rest
+ * step 2: one Pod's readiness probe fails → NotReady, but its IP is still in the slice
+ * step 3: the endpoint controller drops the IP from the slice → traffic reroutes to the rest
  */
 interface RoutePod {
   name: string
@@ -39,14 +43,21 @@ const props = withDefaults(
       { name: 'web-6f8c-7nqld', ip: '10.244.0.8' },
       { name: 'web-6f8c-lm4tt', ip: '10.244.0.9' },
     ],
-    removeAt: 2,
+    removeAt: 3,
   },
 )
 
-// The last Pod drops out of the EndpointSlice once step reaches removeAt.
-const isReady = (i: number) => !(props.step >= props.removeAt && i === props.pods.length - 1)
+// The last Pod's readiness probe fails one step BEFORE its endpoint is removed:
+// NotReady at removeAt - 1 (IP still listed), gone from the slice at removeAt.
+const isReady = (i: number) => !(props.step >= props.removeAt - 1 && i === props.pods.length - 1)
+const isRemoved = (i: number) => props.step >= props.removeAt && i === props.pods.length - 1
+const isLeaving = (i: number) => !isReady(i) && !isRemoved(i)
 const routing = computed(() => props.step >= 1)
-const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p) => p.ip))
+const endpoints = computed(() =>
+  props.pods
+    .map((p, i) => ({ ip: p.ip, leaving: isLeaving(i), removed: isRemoved(i) }))
+    .filter((e) => !e.removed),
+)
 </script>
 
 <template>
@@ -60,7 +71,13 @@ const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p)
         <div class="kw-route-slice">
           <div class="kw-route-slice-label">EndpointSlice</div>
           <TransitionGroup name="kw-route-ep" tag="div" class="kw-route-eps">
-            <code v-for="ip in endpoints" :key="ip" class="kw-route-ep">{{ ip }}</code>
+            <code
+              v-for="ep in endpoints"
+              :key="ep.ip"
+              class="kw-route-ep"
+              :class="{ 'is-leaving': ep.leaving }"
+              >{{ ep.ip }}</code
+            >
             <span v-if="endpoints.length === 0" key="empty" class="kw-route-ep is-empty"
               >&lt;none&gt;</span
             >
@@ -76,7 +93,11 @@ const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p)
           v-for="(pod, i) in props.pods"
           :key="pod.name"
           class="kw-route-pod"
-          :class="{ 'is-out': !isReady(i), 'is-hot': routing && isReady(i) }"
+          :class="{
+            'is-out': isRemoved(i),
+            'is-failing': isLeaving(i),
+            'is-hot': routing && isReady(i),
+          }"
         >
           <div class="kw-route-pod-head">
             <K8sIcon kind="pod" variant="unlabeled" size="0.95rem" alt="" class="kw-route-pod-logo" />
@@ -98,13 +119,18 @@ const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p)
         <code>{{ props.selector }}</code> and writes each Pod's IP into the
         <strong>EndpointSlice</strong> — the live list of who is behind the stable ClusterIP.
       </template>
-      <template v-else-if="props.step === 1">
+      <template v-else-if="props.step < props.removeAt - 1">
         A request to the ClusterIP is <strong>load-balanced</strong> across every address in
         the slice — three Pods, three ways to answer.
       </template>
+      <template v-else-if="props.step < props.removeAt">
+        One Pod is <strong>{{ props.reason }}</strong>: it flips to <strong>NotReady</strong> —
+        still <code>Running</code>, and for a beat its IP is still in the slice. The endpoint
+        controller hasn't reacted yet.
+      </template>
       <template v-else>
-        One Pod is <strong>{{ props.reason }}</strong>: still <code>Running</code>, but dropped
-        from the slice — so traffic reroutes to the healthy two, with no error to the caller.
+        Now the endpoint controller <strong>drops the IP from the slice</strong> — traffic
+        reroutes to the healthy two, with no error to the caller.
         <span class="kw-muted">(This is exactly the readiness behaviour S14 builds on.)</span>
       </template>
     </div>
@@ -184,6 +210,13 @@ const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p)
   color: var(--kw-danger);
 }
 
+/* The failing Pod's IP while it is NotReady but not yet dropped from the slice. */
+.kw-route-ep.is-leaving {
+  border-color: var(--kw-danger);
+  color: var(--kw-danger);
+  border-style: dashed;
+}
+
 .kw-route-arrow {
   font-size: 1.6rem;
   color: var(--kw-text-faint);
@@ -220,6 +253,12 @@ const endpoints = computed(() => props.pods.filter((_, i) => isReady(i)).map((p)
 .kw-route-pod.is-out {
   opacity: 0.5;
   border-color: var(--kw-danger);
+}
+
+/* Readiness failed, endpoint not yet removed: alarmed but still fully present. */
+.kw-route-pod.is-failing {
+  border-color: var(--kw-danger);
+  box-shadow: 0 0 0 1px var(--kw-danger) inset;
 }
 
 .kw-route-pod-head {

--- a/pages/S07-service/index.md
+++ b/pages/S07-service/index.md
@@ -179,7 +179,8 @@ deployment.yaml, it doesn't edit it.
 <v-clicks at="1">
 
 - The ClusterIP never moves; requests **load-balance** across whatever is in the slice right now.
-- Fail one Pod's **readiness** and it leaves the slice while still `Running` — traffic reroutes, callers see nothing.
+- Fail one Pod's **readiness** and it flips **NotReady** — still `Running`, and for a beat its IP is still in the slice.
+- Then the endpoint controller **drops it from the slice** — traffic reroutes to the healthy two, callers see nothing.
 
 </v-clicks>
 </div>
@@ -187,8 +188,10 @@ deployment.yaml, it doesn't edit it.
 <!--
 Speaker: this is the shared US-X3 service-routing animation, owned here and reused
 by S14 for the readiness-probe story (same component, the removed Pod is the
-readiness-failing one). Click through: slice populated → request fans out →
-one Pod goes NotReady and drops from the slice, traffic reroutes to two. Land the
+readiness-failing one). Click through FOUR states: slice populated → request fans
+out → one Pod goes NotReady while its IP is STILL listed (the probe failed; the
+endpoint controller hasn't reacted yet — that little window is real) → the
+controller drops the IP from the slice and traffic reroutes to two. Land the
 bridge: "membership in the slice = readiness, and S14 makes that a knob." The lab
 proves the dark version — a wrong selector empties the slice entirely.
 -->

--- a/pages/S14-probes/index.md
+++ b/pages/S14-probes/index.md
@@ -264,9 +264,10 @@ all three Pods reach READY 1/1.
 <v-clicks at="1">
 
 - Steady state: the Service load-balances across **all three** endpoints.
-- One Pod's readiness probe starts failing — it flips to **NotReady**, still `Running`.
-- The endpoint controller **drops it from the EndpointSlice**; the ClusterIP now targets the
-  healthy two. **No error reaches the caller** — that's zero-downtime by design.
+- One Pod's readiness probe starts failing — it flips to **NotReady**, still `Running`, and
+  for a beat its IP is still in the slice.
+- The endpoint controller **drops it from the EndpointSlice**; traffic reroutes to the healthy
+  two — **no error reaches the caller**.
 
 </v-clicks>
 </div>
@@ -275,9 +276,11 @@ all three Pods reach READY 1/1.
 Speaker: this is the S07 ServiceRouting animation, reused — readiness is literally the
 mechanism that decides who's in a Service's EndpointSlice. Drive with clicks: (0) three Ready
 Pods, three endpoints. (1) a request fans out — load-balanced. (2) one Pod's readiness goes
-red; it stays Running (this is the crucial part — it is NOT restarted, NOT deleted) but its IP
-leaves the slice, so kube-proxy stops routing to it. The other two absorb the traffic; the user
-sees nothing. This is exactly what a rolling update leans on: a new Pod is kept out of the slice
+red; it stays Running (this is the crucial part — it is NOT restarted, NOT deleted) and for a
+beat its IP is STILL in the slice — kubelet has marked it NotReady but the endpoint controller
+hasn't reconciled yet. (3) the controller drops the IP from the slice, kube-proxy reprograms,
+and traffic stops reaching it. The other two absorb the traffic; the user sees nothing —
+that's zero-downtime by design. This is exactly what a rolling update leans on: a new Pod is kept out of the slice
 until readiness passes, so users never touch a half-warmed replica. In the lab you'll cause
 this by POSTing /fail to ONE Pod (its /ready flips to 503) and watch its IP vanish from
 `get endpointslices` while curl keeps returning 200 from the others. Contrast with liveness on

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -1421,3 +1421,66 @@ describe('animated component click budgets (US-FIX-ANIM-CLICKS)', () => {
     )
   })
 })
+
+describe('S07/S14 — the NotReady beat precedes the reroute (US-FIX-REMOVEAT-BEAT)', () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+  const visibleOf = (rel) => stripHtmlComments(readFileSync(join(repoRoot, rel), 'utf8'))
+  const componentSource = () =>
+    readFileSync(join(repoRoot, 'components', 'ServiceRouting.vue'), 'utf8')
+
+  it('ServiceRouting documents four states — NotReady (step 2) distinct from the reroute (step 3)', () => {
+    assert.equal(
+      documentedMaxStep(repoRoot, 'ServiceRouting'),
+      3,
+      'the fused "NotReady + reroute" click must be split into two documented steps',
+    )
+    const header = componentSource().match(/\/\*\*[\s\S]*?\*\//)[0]
+    assert.match(
+      header,
+      /^\s*\*\s*step 2:.*NotReady.*still in the slice/im,
+      'step 2 must be the intermediate state: probe failed, endpoint still listed',
+    )
+    assert.match(
+      header,
+      /^\s*\*\s*step 3:.*reroutes/im,
+      'step 3 must be the state where the slice updates and traffic reroutes',
+    )
+  })
+
+  it('the component fails readiness one step BEFORE it removes the endpoint', () => {
+    const src = componentSource()
+    assert.match(
+      src,
+      /step >= props\.removeAt - 1/,
+      'NotReady must fire at removeAt - 1 (readiness probe fails first)',
+    )
+    assert.match(
+      src,
+      /step >= props\.removeAt\b(?!\s*-)/,
+      'endpoint removal must key on removeAt itself — one step after the probe failure',
+    )
+  })
+
+  for (const rel of ['pages/S07-service/index.md', 'pages/S14-probes/index.md']) {
+    it(`${rel} narrates NotReady-still-in-the-slice before the slice drop, in click order`, () => {
+      const visible = visibleOf(rel)
+      assert.match(
+        visible,
+        /NotReady[\s\S]*?still in the slice[\s\S]*?drops it from the (?:Endpoint)?[Ss]lice/,
+        'the NotReady beat (endpoint still listed) must come before the reroute beat on-slide',
+      )
+    })
+
+    it(`${rel} reserves exactly the 3 clicks the ServiceRouting contract needs`, async () => {
+      const abs = join(repoRoot, rel)
+      const deck = await parseDeck(readFileSync(abs, 'utf8'), abs)
+      const slide = deck.slides.find((s) => s.content.includes('<ServiceRouting'))
+      assert.ok(slide, `${rel} must keep its ServiceRouting slide`)
+      assert.equal(
+        slideClickBudget(slide),
+        3,
+        'the slide budget must reach step 3 so the reroute beat is reachable',
+      )
+    })
+  }
+})


### PR DESCRIPTION
## Complaint (operator board, open since v0.5.0)

On S07 (Services) the operator asked for a distinct intermediate animation state where one Pod goes **NotReady BEFORE traffic reroutes**. `ServiceRouting.vue` fused those into one click: `isReady()` flipped at `step >= removeAt` and drove **both** the NotReady badge and the `endpoints` filter, so the Pod went NotReady and vanished from the EndpointSlice simultaneously. S14 even narrated two beats in its bullets (clicks 2 and 3) while the component rendered both at step 2 and nothing new at step 3. Out of scope for PR #38 (net-zero prose constraint); in scope here.

## Step contract — before / after

**Before (max step 2, fused):**
- step 0: Service + selector, all Pods in the slice (steady state)
- step 1: a request fans out across all endpoints (load-balanced)
- step 2: one Pod goes NotReady -> leaves the slice -> traffic reroutes to the rest

**After (max step 3, split):**
- step 0: Service + selector, all Pods in the slice (steady state)
- step 1: a request fans out across all endpoints (load-balanced)
- step 2: one Pod's readiness probe fails -> NotReady, but its IP is still in the slice
- step 3: the endpoint controller drops the IP from the slice -> traffic reroutes to the rest

`removeAt` (default now 3) stays 'the step the endpoint leaves the slice'; readiness fails at `removeAt - 1`. This mirrors real behavior: kubelet marks the Pod NotReady first, the endpoint controller reconciles the EndpointSlice next, then kube-proxy stops routing — the propagation window is real and now teachable.

## Slide changes

- **S07**: the fused second bullet became two (NotReady-still-in-slice, then slice-drop/reroute), giving the slide the 3-click budget the contract needs. Speaker note narrates four states.
- **S14**: middle bullet gains the still-in-slice nuance; last bullet tightened to one line (its wrap was crowding the footer once the middle bullet grew — 'zero-downtime by design' moved to the speaker note). Speaker note renumbered to four states with the kubelet -> endpoint controller -> kube-proxy chain.

## Visual evidence (rendered per click, scale 2)

Global slides 72 (S07) and 145 (S14), 4 frames each:
- step 2 frame: Pod card red with **NotReady ✗** while its IP `10.244.0.9` is **still listed** in the EndpointSlice as a red dashed 'leaving' chip — visibly distinct on both slides.
- step 3 frame: IP gone from the slice, Pod dimmed, reroute caption; healthy two remain highlighted.
- No overflow after the S14 bullet tightening; S07 clean at every frame.
- Pre-existing nit left alone: the shared caption's '(…readiness behaviour S14 builds on)' parenthetical also shows on S14 itself.

## Tests (TDD, every assertion mutation-verified break->red->restore->green)

6 new tests in `scripts/deck.test.mjs` (89 -> 95, baseline untouched):
- contract lock: `documentedMaxStep === 3` + step 2/step 3 wording (mutation: deleting the step-3 line -> red)
- split-condition lock: NotReady at `removeAt - 1`, removal at `removeAt` (mutation: re-fusing -> red)
- S07 + S14 beat-order locks: NotReady-still-in-slice narrated before the slice drop (mutations: removing the nuance -> red)
- S07 + S14 reachability locks: click budget exactly 3 (mutations: deleting a bullet -> red, also trips the pre-existing starvation gate)

## Timing accounting

No slides added or removed; one extra click on S07 (~15s of talk) absorbed within S07's existing [30, 30] — sectionTimings, syllabus, and the timing template are untouched and still agree.

## Gates

- `pnpm decks:check` OK (6 entries, 28 sections)
- `pnpm test:deck` 95 pass / 0 fail
- `pnpm build` OK
- markdownlint (`pnpm lint`) 0 issues / 55 files
- `pnpm link-check` OK (14 docs)
- `node scripts/dependency-audit.mjs` exit 0

Files touched: `components/ServiceRouting.vue`, `pages/S07-service/index.md`, `pages/S14-probes/index.md`, `scripts/deck.test.mjs`. No timing surfaces needed changes.