### PR TITLE
🔒️ fix(deps): clear the mermaid and ajv advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vue": "^3.5.33"
   },
   "devDependencies": {
-    "ajv": "8.17.1",
+    "ajv": "8.18.0",
     "markdownlint-cli2": "^0.23.2",
     "playwright-chromium": "^1.61.1",
     "sharp": "^0.35.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   nanoid@>=3.0.0 <4.0.0: 3.3.17
   dompurify: 3.4.13
   '@hono/node-server': 2.1.0
+  mermaid: 11.16.1
 
 importers:
 
@@ -28,8 +29,8 @@ importers:
         version: 3.5.39(typescript@6.0.3)
     devDependencies:
       ajv:
-        specifier: 8.17.1
-        version: 8.17.1
+        specifier: 8.18.0
+        version: 8.18.0
       markdownlint-cli2:
         specifier: ^0.23.2
         version: 0.23.2
@@ -1312,8 +1313,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
@@ -2372,8 +2373,8 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  mermaid@11.16.0:
-    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4147,7 +4148,7 @@ snapshots:
       fuse.js: 7.5.0
       katex: 0.18.1
       lz-string: 1.5.0
-      mermaid: 11.16.0
+      mermaid: 11.16.1
       monaco-editor: 0.56.0
       nanotar: 0.3.0
       pptxgenjs: 4.0.1
@@ -4244,7 +4245,7 @@ snapshots:
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.0(@types/node@22.20.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.6(vite@8.2.0(@types/node@22.20.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
       katex: 0.18.1
-      mermaid: 11.16.0
+      mermaid: 11.16.1
       monaco-editor: 0.56.0
       shiki: 4.4.1
       unocss: 66.7.5(vite@8.2.0(@types/node@22.20.0)(jiti@2.7.0)(yaml@2.9.0))
@@ -4908,7 +4909,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.5
@@ -5996,7 +5997,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,13 @@ overrides:
   # 1.19.15+ is patched on the 1.x line; pin 2.1.0 so the alert clears.
   # MCP only needs getRequestListener from this package.
   "@hono/node-server": 2.1.0
+  # Five advisories against the mermaid @slidev/client pulls in, all first
+  # patched in 11.16.1: prototype pollution in the architecture renderer
+  # (GHSA-2v8p-3f2j-5mp7) and the config APIs (GHSA-c4c3-pg64-4m4v), DoS in the
+  # radar (GHSA-rhh3-jpg6-66xh) and XY-chart (GHSA-6x64-9x62-f2gx) renderers,
+  # and sibling-element CSS injection (GHSA-3rrr-jr9j-h3q3). The deck only uses
+  # flowchart and stateDiagram-v2, so this is a patch bump on the same line.
+  mermaid: 11.16.1
 
 # pnpm 11 minimumReleaseAge gate: allow this override pin through when fresh on the registry.
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## What

Clears every dependency advisory in this repo that **has** a fix, and documents why the two that remain don't.

| Package | Advisories | Action |
| --- | --- | --- |
| `mermaid` 11.16.0 → **11.16.1** | 5 (4 moderate, 1 low) | override bumped |
| `ajv` 8.17.1 → **8.18.0** | 1 moderate | direct devDependency bumped |
| `image-size` 1.2.1 | 2 **high** | **no fix exists** — already waived, see below |

## mermaid — all five fixed in 11.16.1

Pulled in transitively by `@slidev/client`. All five advisories are first patched in 11.16.1, so this is a patch bump on the same line, added to the existing override block:

- `GHSA-2v8p-3f2j-5mp7` — architecture-diagram prototype pollution
- `GHSA-c4c3-pg64-4m4v` — config-API prototype pollution
- `GHSA-rhh3-jpg6-66xh` — radar-diagram DoS
- `GHSA-6x64-9x62-f2gx` — XY-chart infinite-loop DoS
- `GHSA-3rrr-jr9j-h3q3` — sibling-element CSS injection

**Not reachable from this deck.** The only mermaid usage in the repo is two blocks in `slides-templates.md` — a `flowchart TD` (line 303) and a `stateDiagram-v2` (line 826). None of the affected renderers (architecture, radar, XY chart) are used.

## ajv — hygiene

`GHSA-2g4f-4pwh-qvx6` (`$data` ReDoS), first patched in 8.18.0. Only `scripts/quiz/validate.mjs` imports ajv and it never enables `$data`, so this was not exposure either — but it's a pinned direct devDependency, so the bump is free.

## image-size — deliberately untouched

`GHSA-w3rx-r6r6-pgpr` (ICNS) and `GHSA-5p2g-fcmc-qvqq` (JXL/HEIF) are both **high**, but **no patched release exists**: npm's latest `image-size` is 2.0.2 and the vulnerable range is `<= 2.0.2`. Overriding would clear nothing and would drag `pptxgenjs` across a major-version boundary.

Both already carry documented, dated exceptions in `supply-chain/dependency-audit.json` (expire 2026-10-08). The sole path is `pptxgenjs` → slidev PPTX export, which no script in `package.json` invokes, and the parsers only ever see this repo's own slide assets.

## Verification

`slidev build` only proves the deck *parses*, and `pnpm build` does not even include `slides-templates.md` — the one file using mermaid. So the mermaid slides were rendered to PNG on both versions and compared:

```
4782166b723eb781040206d5bd39cd61ba823690a6ca6e8941f4faf17d596855  render/28.png    (11.16.1)
4782166b723eb781040206d5bd39cd61ba823690a6ca6e8941f4faf17d596855  baseline/28.png  (11.16.0)
```

Byte-for-byte identical. (The minor label clipping visible on that "static baseline" gallery slide is pre-existing and unchanged.)

Gates run locally, all green:

- `node --test scripts/supply-chain-policy.test.mjs scripts/dependency-audit.test.mjs` — 61 pass
- `node scripts/supply-chain-policy.mjs`, `node scripts/dependency-audit.mjs` (live) — **critical=0, high=2 (both waived), moderate=0, low=0**
- `test:deck`, `test:pages`, `test:quiz`, `quiz:validate`, `quiz:license-gate`, `decks:check`
- `build:day1/2/3`, `build:optional`, `build:superset`, `build:3day`, `build:templates`
- `test:labs`, `lint`, `link-check`, `pages-site`, lab-inventory drift, provenance