### PR TITLE
📝 docs(downloads): move the example pins to v0.6.0

### DIFF
--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -40,12 +40,12 @@ Typical artifact names (tag substituted for `<tag>`):
 | `kubernetes-workshop-3day-<tag>.pdf` | Compatibility three-day cut |
 | `kubernetes-workshop-site-<tag>.zip` | Offline HTML bundle |
 
-Example pins from **`v0.5.1`**:
+Example pins from **`v0.6.0`**:
 
-- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-1-v0.5.1.pdf)
-- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-2-v0.5.1.pdf)
-- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.5.1/kubernetes-workshop-day-3-v0.5.1.pdf)
-- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.5.1)
+- [Day 1 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.6.0/kubernetes-workshop-day-1-v0.6.0.pdf)
+- [Day 2 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.6.0/kubernetes-workshop-day-2-v0.6.0.pdf)
+- [Day 3 PDF](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/download/v0.6.0/kubernetes-workshop-day-3-v0.6.0.pdf)
+- [Full / 3-day PDFs and site zip](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.6.0)
 
 Pre-release tags still prepend [known limitations](./beta-limitations.md) to the release
 notes body. How tags are cut: [release.md](./release.md).


### PR DESCRIPTION
Follow-up to #51 and the `v0.6.0` release.

`docs/downloads.md` pinned its example artifact links to `v0.5.1`. Now that [v0.6.0](https://github.com/PlatformRelay/Kubernetes-Workshop/releases/tag/v0.6.0) is published with all six assets, the examples point at the current tag.

Deliberately sequenced **after** the release: updating the pins beforehand would have made `scripts/link-check.mjs` resolve URLs for a tag that did not exist yet.

The page still leads with the `/releases/latest` link — these pins only illustrate the artifact naming scheme.

Gates: `link-check` OK (14 docs, all links and anchors resolve), `pnpm lint` 0 issues, `pages-site` 5/5 pass.