### PR TITLE
:bug: fix(deck): keep ServiceRouting traffic highlight through the NotReady beat

### DIFF
--- a/components/ServiceRouting.vue
+++ b/components/ServiceRouting.vue
@@ -17,6 +17,7 @@ import { computed } from 'vue'
  * step 0: Service + selector, all Pods in the slice (steady state)
  * step 1: a request fans out across all endpoints (load-balanced)
  * step 2: one Pod's readiness probe fails → NotReady, but its IP is still in the slice
+ *         (still a traffic target — kube-proxy has not dropped it yet)
  * step 3: the endpoint controller drops the IP from the slice → traffic reroutes to the rest
  */
 interface RoutePod {
@@ -96,7 +97,7 @@ const endpoints = computed(() =>
           :class="{
             'is-out': isRemoved(i),
             'is-failing': isLeaving(i),
-            'is-hot': routing && isReady(i),
+            'is-hot': routing && !isRemoved(i),
           }"
         >
           <div class="kw-route-pod-head">
@@ -259,6 +260,13 @@ const endpoints = computed(() =>
 .kw-route-pod.is-failing {
   border-color: var(--kw-danger);
   box-shadow: 0 0 0 1px var(--kw-danger) inset;
+}
+
+/* Probe failed, IP still in the slice: keep the traffic highlight. is-failing
+   alone would paint the pod as already off the path. */
+.kw-route-pod.is-hot.is-failing {
+  border-color: var(--kw-accent);
+  box-shadow: 0 0 0 1px var(--kw-accent) inset;
 }
 
 .kw-route-pod-head {

--- a/scripts/deck.test.mjs
+++ b/scripts/deck.test.mjs
@@ -1461,6 +1461,28 @@ describe('S07/S14 — the NotReady beat precedes the reroute (US-FIX-REMOVEAT-BE
     )
   })
 
+  it('the failing pod stays a traffic target at the NotReady beat (removeAt - 1)', () => {
+    const src = componentSource()
+    const hotBind = src.match(/'is-hot':\s*([^,\n]+)/)
+    assert.ok(hotBind, 'is-hot class binding must exist on the pod')
+    const expr = hotBind[1].trim()
+    assert.doesNotMatch(
+      expr,
+      /^routing\s*&&\s*isReady\(i\)$/,
+      'is-hot must not drop solely because the pod is NotReady — kube-proxy still targets IPs listed in the slice',
+    )
+    assert.match(
+      expr,
+      /routing\s*&&\s*!isRemoved\(i\)/,
+      'is-hot must follow slice membership: still listed ⇒ still a traffic target',
+    )
+    assert.match(
+      src,
+      /\.kw-route-pod\.is-hot\.is-failing[\s\S]{0,240}--kw-accent/,
+      'combined NotReady+in-slice CSS must keep the traffic (accent) highlight; is-failing must not win the cascade alone',
+    )
+  })
+
   for (const rel of ['pages/S07-service/index.md', 'pages/S14-probes/index.md']) {
     it(`${rel} narrates NotReady-still-in-the-slice before the slice drop, in click order`, () => {
       const visible = visibleOf(rel)


### PR DESCRIPTION
## Summary
- Follow-up **#50-F1**: at the NotReady beat (`removeAt - 1`) the failing Pod's IP is still in the EndpointSlice, so it remains a Service traffic target.
- `is-hot` is now `routing && !isRemoved(i)` instead of `routing && isReady(i)`. Combined `.is-hot.is-failing` CSS keeps the accent traffic highlight so `is-failing` does not win the cascade and look like traffic already left.
- Deck test locks the binding and combined CSS; restoring `routing && isReady(i)` as the sole hot condition goes red. Existing four-state NotReady vs reroute tests unchanged.

## Test plan
- [x] `pnpm test:deck`
- [x] `pnpm build:day1`
- [x] `pnpm build:day2`
- [ ] Visual: S07/S14 ServiceRouting step 2 — failing pod still accent-hot; step 3 — `is-out`, highlight gone.

**Out of scope (#50-F2):** EndpointSlice v1 `ready: false` vs caption "drops the IP from the slice" would need S07/S14 slide prose; left unchanged.