### PR TITLE
:memo: docs(adr): ADR 0014 — i18n without forking + workshop-i18n cut

### DIFF
--- a/docs/decisions/0014-i18n-options/01-extracted-catalogs-generated-decks.md
+++ b/docs/decisions/0014-i18n-options/01-extracted-catalogs-generated-decks.md
@@ -1,0 +1,163 @@
+# Option: Extracted catalogs + generated decks + locale overrides
+
+- **Cluster:** sidecar-catalog (+ selective locale structure)
+- **When translation happens:** CI-generate (author-time English; locale at compose)
+- **Parent:** [ADR 0014](../0014-i18n-without-forking.md) (proposed catalog; not accepted)
+- **Role:** primary full-corpus candidate — slides, labs, quiz — with overflow escape hatch
+
+> **Architecture follow-up:** the
+> [Workshop Localization Hub architecture pack](../0014-tms-architecture/README.md) turns this
+> sketch into a mature standalone design. It delegates translation memory, glossary, translator UI,
+> and linguistic review to external TMS products while the hub owns extraction, provider
+> conformance, composition, visual review, and release.
+
+## Shape
+
+English markdown stays the concrete, readable source. A tool walks each surface, extracts
+translatable nodes into a sidecar catalog, and leaves fences alone. Locale trees are
+**generated**. Where a 1:1 string swap would overflow or mis-teach, a locale may **override** a
+slide (replace one English slide with one or more locale slides) keyed by a stable slide id.
+
+```mermaid
+flowchart TB
+  EN["English pages / labs / quiz"]
+  Ext["Extractor"]
+  Cat["Locale catalog + review state"]
+  Ovr["Locale overrides by slide id"]
+  Gen["Generator"]
+  Out["Generated locale deck"]
+  Q["Review queue / CI report"]
+  EN --> Ext --> Cat
+  EN --> Gen
+  Cat --> Gen
+  Ovr --> Gen
+  Gen --> Out
+  Ext --> Q
+  Cat --> Q
+```
+
+### Layers
+
+| Layer | What it holds | When to use |
+| --- | --- | --- |
+| Catalog | msgid → msgstr for prose, kickers, notes, quiz fields | Default for every string |
+| Review state | `fuzzy` / `needs-review` / `accepted` + English hash | On every English change |
+| Overrides | Full Slidev markdown fragments for `de` / `pt-BR` / … | Overflow, reflow, or pedagogy that cannot be 1:1 |
+| Generated output | Composed locale `pages/` (and lab/quiz renders) | What Slidev and facilitators run — never hand-edited |
+
+Facilitators compose with something like `task dev --lang de` (same idea as `--gitops`).
+
+## Stale tracking and human validation
+
+1. English edit → extractor recomputes string ids / content hashes.
+2. Changed or removed source strings mark locale rows **fuzzy** (or drop obsolete ids).
+3. AI may propose replacements for fuzzy rows; status stays `needs-review` until a human accepts.
+4. A report (CI artifact or `task i18n:status`) lists open fuzzy / needs-review per locale.
+5. Policy (later ADR): fail the locale export if open fuzzy remain, or fall back to English for
+   those nodes — never invent unmarked strings.
+
+Illustrative catalog metadata (format TBD — gettext, XLIFF, or JSON):
+
+```yaml
+# i18n/de/strings.yaml (illustrative)
+- id: S00.statement-why.kicker
+  source: "Why we're here"
+  sourceHash: "a1b2…"
+  target: "Warum wir hier sind"
+  status: accepted   # fuzzy | needs-review | accepted
+- id: S00.statement-why.body
+  source: "Three days to take you from…"
+  sourceHash: "c3d4…"
+  target: "In drei Tagen…"
+  status: fuzzy      # English changed; human must revalidate
+```
+
+## How the same slide looks
+
+**English source (today)** — unchanged authoring surface
+([`pages/S00-welcome/index.md`](../../../pages/S00-welcome/index.md)):
+
+```md
+---
+layout: statement
+kicker: Why we're here
+slideId: S00.statement-why
+---
+
+Three days to take you from **"what is a container"** to confidently
+**authoring, running, and operating** core Kubernetes workloads.
+```
+
+(`slideId` is illustrative — it may be frontmatter or a comment marker, but must be explicit,
+immutable, and independent of file path or slide index.)
+
+**Catalog path (fits):** generate one German slide from msgstr.
+
+**Override path (overflow — e.g. German too long for one statement slide):**
+
+```md
+# i18n/de/overrides/S00.statement-why.md
+# Replaces English slide S00.statement-why with TWO slides for de
+
+---
+layout: statement
+kicker: Warum wir hier sind
+---
+
+In drei Tagen von **"was ist ein Container"** zu
+**Workloads in Kubernetes sicher erstellen, betreiben und betreiben**.
+
+---
+layout: statement
+kicker: Das Versprechen
+---
+
+Die Hälfte der Zeit ist Folien, die Hälfte Tastatur:
+jeder Konzeptblock endet mit einem Lab **in eurer eigenen** Umgebung.
+```
+
+Generator rule: if `i18n/<lang>/overrides/<slideId>.md` exists, emit that fragment instead of
+catalog-substituted English; otherwise substitute strings in place. Overrides are themselves
+subject to review when the English `sourceHash` for that slide id changes (flag the whole
+override for human revalidation).
+
+## What stays untranslated
+
+Lab and slide fences stay byte-identical across locales (including inside overrides — CI must
+still assert fence equality for shared curriculum commands):
+
+```bash
+kubectl apply --dry-run=server -f pod.yaml
+kubectl apply -f pod.yaml
+```
+
+API kinds, `kubectl`, image refs, and flag names stay in a do-not-translate glossary.
+
+## Comparing alternatives under these requirements
+
+| Requirement | Catalogs + overrides (this) | Parallel trees (#55) | `$t()` keys | Captions only | Quiz/labs first |
+| --- | --- | --- | --- | --- | --- |
+| Full localize (slides too) | Yes | Yes | Yes | No | No |
+| English stays readable | Yes | Yes (EN tree) | No | Yes | Yes |
+| Auto stale / retranslate | Built-in fuzzy | Manual / custom bot | Tooling-dependent | Weak | Yes on subset |
+| New/split slides for DE | Override files | Free rewrite | Conditionals / extra components | No | N/A for slides |
+| Drift risk | Low if CI enforced | High | Medium | Low | Low on subset |
+
+**Why not pure catalogs without overrides?** German length will overflow; facilitators would
+silently ship clipped slides or shrink fonts. Overrides are the escape hatch without forking the
+whole library.
+
+**Why not parallel trees for overflow?** They solve layout by copying everything, then lose
+automatic fuzzy tracking unless you rebuild the same catalog machinery anyway.
+
+## Consequences
+
+| Dimension | Effect |
+| --- | --- |
+| Editability | English markdown stays readable; overrides are rare, explicit, per slide id. |
+| Drift | Fuzzy + review queue + fence-identity CI. |
+| Third language | New catalog + optional overrides directory. |
+| AI | Draft fuzzy / draft override prose; human accept. |
+| Fit to 0003 | Strong — one English library; locales are generated composition. |
+| Cost | Highest of the three full sketches: Slidev round-trip + override composer + review UX. |
+| Honesty | Full locale workshop is the goal; captions/quiz-first are not substitutes. |

--- a/docs/decisions/0014-i18n-options/02-caption-subtitle-track.md
+++ b/docs/decisions/0014-i18n-options/02-caption-subtitle-track.md
@@ -1,0 +1,81 @@
+# Option: Caption / subtitle track
+
+- **Cluster:** shrink-the-problem
+- **When translation happens:** author-time (sidecar track; English deck unchanged)
+- **Parent:** [ADR 0014](../0014-i18n-without-forking.md) (proposed catalog; not accepted)
+- **Role:** overlay / stopgap only — **does not meet** the full-corpus localization goal
+
+## Shape
+
+The English section library is never forked. A sidecar maps `section + slide index` (or a stable
+slide id) to locale captions and optional speaker notes. The projector shows English; the room can
+follow a Portuguese track (on-screen caption layer, presenter notes pane, or printed companion).
+
+If the workshop goal is a full locale deck (including German overflow handled by real slides), use
+[option 01 — catalogs + overrides](01-extracted-catalogs-generated-decks.md) instead.
+
+```mermaid
+flowchart LR
+  Deck["English Slidev deck"]
+  Track["i18n/pt-BR/captions.yaml"]
+  UI["Caption overlay / notes pane"]
+  Deck --> UI
+  Track --> UI
+```
+
+This is the cheapest landing zone for a full-prose contribution like PR #55 without accepting a
+parallel tree: harvest captions and notes into the track; leave `pages/` alone.
+
+## How the same slide looks
+
+**English source (today)** — still the only slide file
+([`pages/S00-welcome/index.md`](../../../pages/S00-welcome/index.md)):
+
+```md
+---
+layout: statement
+kicker: Why we're here
+---
+
+Three days to take you from **"what is a container"** to confidently
+**authoring, running, and operating** core Kubernetes workloads.
+```
+
+**Sidecar track** (illustrative):
+
+```yaml
+# i18n/pt-BR/captions.yaml
+S00:
+  - slide: statement-why   # or 0-based index within the section
+    kicker: Por que estamos aqui
+    caption: >
+      Três dias para levar você de "o que é um container" a criar,
+      executar e operar workloads Kubernetes com confiança.
+    speaker: >
+      Diga o resultado em voz alta. O contrato 50/50 é a promessa do
+      workshop — cada ideia é praticada na hora.
+```
+
+The markdown on disk does not change. The locale never becomes a second `index.md`.
+
+## What stays untranslated
+
+Everything on the projector that is curriculum YAML/bash — and, in this option, **most of the
+slide body itself** stays English by design. Lab fences are untouched:
+
+```bash
+kubectl apply --dry-run=server -f pod.yaml
+kubectl apply -f pod.yaml
+```
+
+## Consequences
+
+| Dimension | Effect |
+| --- | --- |
+| Editability | English library untouched; zero freeze of authoring. |
+| Drift | Track can lag; missing keys fall back to English captions or show nothing. |
+| Third language | Another track file; still one deck. |
+| AI | Can draft caption rows; human review still required for teaching terms. |
+| Fit to 0003 | Strong — does not invent a second library. |
+| Honesty | This is a Portuguese *overlay*, not a Portuguese workshop. Learners still read English slides. |
+| Cost | Low engineering; does not satisfy "full locale deck" expectations. |

--- a/docs/decisions/0014-i18n-options/03-quiz-and-lab-prose-first.md
+++ b/docs/decisions/0014-i18n-options/03-quiz-and-lab-prose-first.md
@@ -1,0 +1,98 @@
+# Option: Quiz and lab prose first
+
+- **Cluster:** shrink-the-problem → path into sidecar-catalog
+- **When translation happens:** author-time / CI on structured surfaces first
+- **Parent:** [ADR 0014](../0014-i18n-without-forking.md) (proposed catalog; not accepted)
+- **Role:** incremental **spike path** toward catalogs — **not** the final answer if slides must be localized too
+
+## Shape
+
+Defer Slidev AST round-trip risk while proving fuzzy tracking and fence identity. Localize surfaces
+that are already structured (then extend to slides via
+[option 01](01-extracted-catalogs-generated-decks.md)):
+
+1. **Quiz** — [`quiz/questions.json`](../../../quiz/questions.json) keyed by ids like
+   `S00-Q-RET-01`. A locale file overrides `prompt` / `options[].text` / `explanation` by id.
+2. **Lab prose** — extract paragraphs and headings from `labs/day-*/NN-topic.md`; leave fenced
+   bash/YAML identical.
+
+The projector (slides) stays English — often correct for Kubernetes teaching vocabulary. This
+proves catalog discipline before betting on ~400 slides.
+
+```mermaid
+flowchart TB
+  subgraph v1 [v1 scope]
+    Q["quiz/questions.json"]
+    QL["quiz/i18n/pt-BR.json"]
+    L["labs/** prose"]
+    LC["labs/i18n/pt-BR/** catalogs"]
+    Q --> QL
+    L --> LC
+  end
+  subgraph later [Later if spike holds]
+    S["pages/** via catalogs + generate"]
+  end
+  v1 -.-> later
+```
+
+## How the same slide looks
+
+**Slides:** unchanged. The S00 statement slide stays English on the projector:
+
+```md
+---
+layout: statement
+kicker: Why we're here
+---
+
+Three days to take you from **"what is a container"** to confidently
+**authoring, running, and operating** core Kubernetes workloads.
+```
+
+**Quiz locale** (illustrative override by id):
+
+```json
+{
+  "S00-Q-RET-01": {
+    "prompt": "Uma tarefa do lab parece travada. O que este workshop garante sobre cada tarefa e pergunta?",
+    "options": {
+      "spoiler": "Cada tarefa e pergunta tem um spoiler recolhido com a solução ou saída esperada.",
+      "ask-later": "As respostas ficam retidas até o quiz ao vivo revelá-las no fim do dia.",
+      "exam-mode": "As tarefas ficam sem solução de propósito para a sala fazer um exame."
+    },
+    "explanation": "Todo lab envia um spoiler em <details> para o aluno destravar sem esperar o facilitador."
+  }
+}
+```
+
+**Lab prose catalog** (illustrative) vs fence left alone:
+
+```yaml
+# labs/i18n/pt-BR/05-pod.yaml
+objective: >
+  Criar, executar, inspecionar e apagar um Pod — a menor unidade implantável —
+  e observar o ciclo de vida.
+```
+
+```bash
+# still English in labs/day-1/05-pod.md — never translated
+kubectl apply --dry-run=server -f pod.yaml
+kubectl apply -f pod.yaml
+```
+
+## What stays untranslated
+
+All executable fences and happy-path manifests. Slide library (in v1). API kinds and kubectl in a
+glossary even when lab prose is localized.
+
+## Consequences
+
+| Dimension | Effect |
+| --- | --- |
+| Editability | Slides stay English; quiz/labs gain catalogs without key-souping the deck. |
+| Drift | Id-stable quiz keys are easy to merge; lab catalogs need the same fuzzy story as option 01. |
+| Third language | Another quiz JSON + lab catalog set. |
+| AI | Strong fit: quiz options are short strings with clear glossary rules. |
+| Fit to 0003 | Neutral for slides (unchanged); prepares the catalog toolchain ADR 0003 composition would reuse. |
+| Honesty | Industry language on the projector, local language on the keyboard — a deliberate teaching choice. |
+| Cost | Lowest spike cost; does not deliver localized slides. |

--- a/docs/decisions/0014-i18n-options/README.md
+++ b/docs/decisions/0014-i18n-options/README.md
@@ -1,0 +1,18 @@
+# ADR 0014 option sketches
+
+Full concept sketches referenced from
+[ADR 0014](../0014-i18n-without-forking.md). These are **not** accepted ADRs; they are comparable
+design notes (mermaid + worked samples).
+
+| File | Concept | Full-corpus slides? |
+| --- | --- | --- |
+| [01-extracted-catalogs-generated-decks.md](01-extracted-catalogs-generated-decks.md) | Catalogs + generate + **locale overrides** (primary candidate) | Yes |
+| [02-caption-subtitle-track.md](02-caption-subtitle-track.md) | Caption / subtitle track | No (overlay) |
+| [03-quiz-and-lab-prose-first.md](03-quiz-and-lab-prose-first.md) | Quiz and lab prose first | Spike only |
+
+Short-form concepts (parallel trees, inline bilingual, `$t()`, runtime overlay, YAML beats) live
+in the umbrella ADR only.
+
+The [Workshop Localization Hub architecture pack](../0014-tms-architecture/README.md) develops the
+primary candidate into a standalone, multi-workshop, multi-TMS design with usability journeys,
+testing architecture, operational boundaries, and proposed implementation ADRs.

--- a/docs/decisions/0014-i18n-without-forking.md
+++ b/docs/decisions/0014-i18n-without-forking.md
@@ -1,0 +1,205 @@
+# ADR 0014: Internationalization without forking the section library
+
+- **Status:** proposed
+- **Scope:** how this workshop ships additional languages for **slides, labs, and quiz**
+  without freezing English authoring or treating a full parallel tree as architecture. This ADR
+  **catalogues concepts and records emerging requirements**; it does **not** choose a final
+  option. A later ADR may accept one design after a spike.
+
+## Context
+
+A community contribution ([PR #55](https://github.com/PlatformRelay/Kubernetes-Workshop/pull/55))
+offered a full Brazilian Portuguese (pt-BR) translation. That PR is the right *intent* and the wrong
+*shape*: a parallel tree of `pages/` and labs recreates the drift problem
+[ADR 0003](0003-deck-composition-superset-and-boil-down.md) already rejected for delivery variants
+(one section library, generated root decks).
+
+The corpus is large and mixed. Roughly 28 sections and ~400 Slidev slides combine layout
+frontmatter (`heading` / `kicker`), markdown prose, HTML-comment speaker notes, Vue islands, and
+fenced YAML/bash. Labs pair the same way. The quiz bank is already structured JSON keyed by
+question id. Slidev has no native content i18n ([slidevjs/slidev#1125](https://github.com/slidevjs/slidev/issues/1125)).
+
+### Goals (operator direction, 2026-08-15)
+
+1. **Localize everything** — slides, labs, and quiz — even if the slide path needs complex tooling.
+   Quiz/lab-only approaches are useful *spikes*, not the end state.
+2. **English markdown stays editable** — ADR 0003 write-once library; no `$t()` key-soup as the
+   primary authoring surface.
+3. **YAML / bash / kubectl / API kinds / image refs stay English** and identical across locales.
+4. **Automatic tracking of stale translation** — when English changes, the matching locale strings
+   (or whole overridden slides) are marked for retranslation / human revalidation. No silent drift.
+5. **Human validation is mandatory** before a locale string or override is considered shipping-grade
+   (AI may draft; humans accept).
+6. **Layout reality** — German (and similar) often needs *more* characters than English. String
+   substitution alone will overflow some slides. Locales must be able to **replace a whole slide**
+   (or split one English slide into several locale slides), not only swap text nodes.
+
+## Elevator pitches
+
+Eight distinct *shapes*. Three are expanded under
+[`0014-i18n-options/`](0014-i18n-options/); five stay short-form below. None is accepted here.
+
+1. **Parallel locale trees** — Copy `pages/` (and labs) per language, as #55 did. Fastest ship;
+   every English edit must be replayed by hand. This is the failure ADR 0003 already rejected for
+   delivery variants.
+2. **Inline bilingual markdown** — Both languages live in the same slide (`<Tr>`, `||`, or a
+   second `lang:` block). Fine for a two-language talk; a third locale and the section library both
+   choke. Overflow still forces duplicated structure.
+3. **Keyed templates (`$t()`)** — Replace prose with keys; YAML holds the strings. Slides become
+   abstract. Authors stop reading markdown and start hunting keys. The literal "replace only text"
+   answer, and the one that freezes *editing*.
+4. **Extracted catalogs + generated decks (+ locale overrides)** — Keep English markdown as it is.
+   A tool extracts translatable nodes into a sidecar (gettext/XLIFF). Locale decks are generated;
+   code fences stay identical. **Fuzzy / needs-review flags** track English churn. Where a
+   translation does not fit (or pedagogy must differ), a locale may **override or split** a slide
+   by stable id. AI may fill *fuzzy* entries, never the source. Structure sits *on top of* markdown.
+5. **Runtime overlay (`?lang=`)** — Same catalogs as (4), applied in the browser instead of
+   generating a tree. Nice switcher; PDF export and CI still need a generate pass. Not a different
+   source model; override slides still need a generate or dual-entry story.
+6. **Caption / subtitle track** — English slides stay English. A sidecar of captions and speaker
+   notes. Useful overlay; **does not meet the full-localization goal**.
+7. **Quiz and lab prose first** — Localize structured quiz JSON and lab paragraphs first; slides
+   later. Strong *incremental spike*; **insufficient alone** if the goal is a full locale workshop.
+8. **YAML beats / screenplay rewrite** — Author structure as YAML, render through Vue templates.
+   Maximum abstraction; it is a new workshop, not an i18n layer.
+
+## Options considered (short-form)
+
+### Parallel locale trees
+
+**Pitch:** as (1). **Fatal trade-off:** no automatic stale tracking without a custom sync bot;
+guaranteed drift. Overflow *is* solvable (you rewrite freely) but at ADR 0003's cost. Not expanded.
+
+### Inline bilingual markdown
+
+**Pitch:** as (2). **Fatal trade-off:** does not scale past two languages; overflow still means
+duplicating slide bodies inline. Not expanded.
+
+### Keyed templates (`$t()`)
+
+**Pitch:** as (3). **Fatal trade-off:** freezes authoring. Warning shape:
+
+```md
+---
+layout: statement
+kicker: {{ $t('s00.why.kicker') }}
+---
+
+{{ $t('s00.why.body') }}
+```
+
+Override/split slides are possible via Vue conditionals, but the day-to-day edit surface is worse.
+Not expanded.
+
+### Runtime overlay (`?lang=`)
+
+**Pitch:** as (5). **Fatal trade-off:** presentation variant of catalogs, not a different source
+model. Export/CI still generate. See
+[01-extracted-catalogs-generated-decks.md](0014-i18n-options/01-extracted-catalogs-generated-decks.md).
+
+### YAML beats / screenplay rewrite
+
+**Pitch:** as (8). **Fatal trade-off:** boils the ocean. Not expanded.
+
+## Options considered (full sketches)
+
+| # | Concept | Meets full localize? | Overflow / new slides? | Stale tracking? | File |
+| --- | --- | --- | --- | --- | --- |
+| 4 | Catalogs + generate + **locale overrides** | Yes (target) | Yes — override/split by slide id | Yes — fuzzy + review queue | [01-…](0014-i18n-options/01-extracted-catalogs-generated-decks.md) |
+| 6 | Caption / subtitle track | No (overlay only) | N/A (English stays) | Partial | [02-…](0014-i18n-options/02-caption-subtitle-track.md) |
+| 7 | Quiz and lab prose first | Partial (spike path) | Labs: prose only | Yes on those surfaces | [03-…](0014-i18n-options/03-quiz-and-lab-prose-first.md) |
+
+Canonical English sample every full sketch may rewrite (from
+[`pages/S00-welcome/index.md`](../../pages/S00-welcome/index.md)):
+
+```md
+---
+layout: statement
+kicker: Why we're here
+---
+
+Three days to take you from **"what is a container"** to confidently
+**authoring, running, and operating** core Kubernetes workloads.
+```
+
+**Primary direction to study (still not accepted):** option **4** with overrides — catalogs for the
+common case, explicit locale slide replacements when German (etc.) cannot fit. Options 6 and 7
+remain documented as overlays / spike hedges, not competitors for the full-corpus goal.
+
+### Mature TMS architecture follow-up
+
+The [Workshop Localization Hub architecture pack](0014-tms-architecture/README.md) expands option 4
+into a proposed standalone product shared by multiple workshops. Its important correction to this
+sketch is that fuzzy tracking, translation memory, terminology, editor UX, and linguistic workflow
+should come from an established TMS rather than custom catalog YAML. The custom hub owns the
+workshop-specific integration: safe extraction, stable identities, provider portability, overrides,
+rendered review, release policy, and evidence.
+
+The pack includes system and deployment diagrams, role-specific journeys, domain and integration
+contracts, an executable-story test architecture, operations/security guidance, an incremental
+delivery plan, and twelve proposed ADRs for the future standalone repository.
+
+### Critical review and optimized cut (2026-08-15)
+
+An adversarial architecture review of the pack concluded: **excellent domain analysis, premature
+product.** Its keepers — explicit immutable identities, the build-vs-buy boundary, English
+authoritative with generated artifacts and governed overrides, fail-closed dual approval,
+story-driven multi-layer tests — survive unchanged. Its runtime does not: a modular-monolith
+service (PostgreSQL, queue, object store, portal, webhook ingestion, SLOs) is speculative
+generality for two workshops, ~two maintainers, and zero shipped localization code, and the
+"every story × two live TMS adapters" requirement bought lock-in insurance no one can afford to
+maintain. XLIFF 2.1 as the canonical format was also inverted: the first TMS target (Weblate)
+documents XLIFF 2 and Markdown support as under development while its gettext PO path is its
+strongest, so PO becomes the working format and XLIFF an export.
+
+The optimized cut now lives as the standalone repository
+**[`PlatformRelay/workshop-i18n`](https://github.com/PlatformRelay/workshop-i18n)** (local:
+`../workshop-i18n`): a stateless, git-native TypeScript CLI — extract → PO catalogs → compose
+locale trees with governed overrides → staleness report — with all localization state committed
+in the consumer workshop repos. Its `docs/adr/0001–0011` supersede this pack's twelve proposed
+ADRs (triage recorded there), and its Spec Kit specs 001–004 are the executable form of the four
+spikes listed under Acceptance below. A service tier may still be built later; its reversal
+trigger (≥3 consumers **and** measured failure of file-based TMS sync) is recorded in that repo's
+ADR 0003.
+
+## Cross-cutting (not separate options)
+
+- **AI as draft, not source.** Fill *fuzzy* catalog entries (and draft override prose) with a
+  do-not-translate glossary (`Pod`, `Deployment`, `kubectl`, `kind`, image names, flag names).
+  Human accepts. Never auto-merge. Never translate fences.
+- **Review queue.** English change → extractor marks fuzzy / `needs-review`; CI or a report lists
+  outstanding items per locale; shipping a locale with open fuzzy entries is a policy choice
+  (fail closed vs English fallback), recorded when accepted.
+- **Overflow gate (aspirational).** Prefer catching overflow in CI (e.g. export/screenshot budget
+  or layout heuristics) so long German does not silently clip. Exact mechanism is spike work.
+- **Weblate / Crowdin** — mature workflow backends behind a conformance-tested adapter boundary, not
+  merely a UI and not the owner of workshop composition or release policy.
+- **Tagged snapshots** — optional *staleness policy* (locale lags an English tag), not a source
+  model.
+- **Browser auto-translate** of the Pages site is out.
+
+## Decision
+
+**Direction chosen; final acceptance pending spike evidence.** Option 4's shape — generated
+locale artifacts + governed slide overrides, covering slides, labs, and quiz — proceeds as a
+**stateless, git-native CLI in the standalone `workshop-i18n` repository** (see the 2026-08-15
+critique above), with translations in committed gettext PO catalogs and Weblate consuming them
+file-based. The pack's service tier and dual-live-adapter requirement are explicitly **not**
+adopted; portability is carried by portable exports plus a conformance-tested port contract.
+
+Do **not** merge a parallel locale tree as the workshop's i18n architecture. Do **not** wrap the
+section library in `$t()` keys without an explicit superseding ADR. Do **not** treat quiz/lab-only
+or caption-only approaches as the final answer if the goal remains full localization.
+
+Acceptance requires a later ADR after spikes: (1) Slidev extract/reinsert round-trip on one section;
+(2) override/split slide composition; (3) fuzzy report + human accept path; (4) fence-identity CI.
+These four spikes are now specified as executable Spec Kit features 001–004 in `workshop-i18n`;
+their evidence closes this ADR via a short superseding acceptance note rather than a new sketch.
+
+## Consequences
+
+- Contributors can compare shapes with samples instead of rediscovering forks.
+- PR #55 can stay open as a *reference* for prose while a language-pack + override landing zone is
+  designed.
+- Roadmap lists internationalization as **exploring** and points here.
+- OpenTofu-Workshop (same Slidev pattern) can reuse this catalog later.

--- a/docs/decisions/0014-tms-architecture/README.md
+++ b/docs/decisions/0014-tms-architecture/README.md
@@ -1,0 +1,113 @@
+# Workshop Localization Hub: architecture pack
+
+- **Status:** partially superseded (2026-08-15) — the domain model, identities, and policies were
+  adopted; the service runtime (database, queue, portal, webhooks) and the dual-live-adapter
+  requirement were **cut** after critical review. The optimized decision set lives in the
+  standalone [`PlatformRelay/workshop-i18n`](https://github.com/PlatformRelay/workshop-i18n)
+  repository (`docs/adr/0001–0011` there triage this pack's twelve proposed ADRs). See the
+  "Critical review and optimized cut" section of [ADR 0014](../0014-i18n-without-forking.md).
+  This pack is preserved as the domain analysis it is.
+- **Target home (as realized):** `workshop-i18n` (the provisional `workshop-localization-hub`
+  name was rejected as promising the deleted service tier)
+- **Audience:** workshop maintainers, translators, reviewers, facilitators, and implementers
+- **Parent decision:** [ADR 0014](../0014-i18n-without-forking.md)
+
+This pack describes a mature localization control plane shared by multiple workshops. It is not a
+proposal to build a general-purpose translation editor. Translators and linguistic reviewers work in
+an established translation-management system (TMS); the hub owns the workshop-specific problems
+those products do not solve:
+
+- extracting translatable content from Slidev, lab Markdown, and structured quizzes;
+- preserving executable examples and Slidev structure exactly;
+- maintaining durable identities across source edits and file moves;
+- synchronizing more than one TMS through one tested adapter contract;
+- rendering locale previews and detecting clipping or structural damage;
+- governing whole-slide overrides and source-change invalidation;
+- releasing only linguistically and visually approved workshop snapshots.
+
+The phrase “every story in multiple TMSs” is interpreted as two requirements:
+
+1. every supported user story must pass against every production TMS adapter; and
+2. every user story must be covered by more than one test layer.
+
+If only the second meaning was intended, the adapter architecture remains valuable: it prevents the
+workshops from becoming locked to one provider.
+
+## Reading map
+
+| Question | Document |
+| --- | --- |
+| What are we building and where are the boundaries? | [System architecture](system-architecture.md) |
+| What does it feel like for each person? | [Usability and journeys](usability-and-journeys.md) |
+| Which outcomes must work in every TMS? | [User stories and traceability](user-stories-and-traceability.md) |
+| What are the entities, identities, and states? | [Domain model and contracts](domain-model-and-contracts.md) |
+| How do repositories and TMS products integrate? | [Integration architecture](integration-architecture.md) |
+| How will the first TMS authority be selected? | [TMS evaluation](tms-evaluation.md) |
+| How is “extremely well tested” made enforceable? | [Testing strategy](testing-strategy.md) |
+| How is it operated, secured, and recovered? | [Operations and security](operations-and-security.md) |
+| How can it be delivered without a big-bang migration? | [Delivery plan](delivery-plan.md) |
+| Which choices are deliberate and reversible? | [Proposed standalone-repository ADRs](adrs/README.md) |
+
+## Decision summary
+
+```mermaid
+flowchart LR
+  Authors["Authors<br/>edit English normally"]
+  Hub["Localization Hub<br/>identity · sync · policy · preview"]
+  TMS["External TMS<br/>translate · glossary · review"]
+  CI["Hermetic renderer<br/>build · export · inspect"]
+  Release["Signed locale release<br/>deck · labs · quiz · report"]
+
+  Authors --> Hub
+  Hub <--> TMS
+  Hub --> CI --> Hub
+  Hub --> Release
+```
+
+The preferred implementation is a **modular monolith with asynchronous workers**, a PostgreSQL
+database, an S3-compatible artifact store, and a small web application plus CLI. The first release
+may run as a CLI and CI job using the same domain modules; the service adds collaboration and
+operational visibility without changing the content model.
+
+## Non-goals
+
+- Reimplementing a translation editor, translation memory, glossary, terminology suggestions, or
+  machine translation.
+- Translating executable fences, Kubernetes API identifiers, image references, paths, or flags.
+- Editing English source through the hub.
+- Treating generated locale Markdown as hand-maintained source.
+- Guaranteeing layout from character-count heuristics alone.
+- Allowing an external TMS webhook to publish a workshop release directly.
+
+## Success criteria
+
+The architecture is acceptable only when a representative, hostile section—not a trivial title
+slide—can complete this loop through at least two adapters:
+
+1. extract and publish translation units;
+2. translate and review them in the external TMS;
+3. import targets repeatedly without duplication or lost review state;
+4. compose normal and overridden slides;
+5. prove protected content and structural invariants;
+6. render live deck and PDF previews;
+7. reject clipping and unreviewed content;
+8. publish an immutable, reproducible locale snapshot;
+9. invalidate exactly the affected approvals after an English edit; and
+10. recover from duplicate, delayed, and out-of-order webhooks.
+
+## Standards and product references
+
+- [XLIFF 2.1](https://docs.oasis-open.org/xliff/xliff-core/v2.1/xliff-core-v2.1.html)
+  defines interoperable localization units, inline codes, states, metadata, validation, and size
+  restrictions. It is the archival portability target, not an assumption that every provider
+  accepts every XLIFF 2.1 feature.
+- [GNU gettext fuzzy entries](https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html)
+  establish the important principle that changed matches require human revision.
+- [Weblate workflow configuration](https://docs.weblate.org/en/latest/admin/projects.html) documents
+  review workflow, quality-based commits, and shared/workspace translation memory.
+- [Weblate Markdown support](https://docs.weblate.org/en/latest/formats/markdown.html) is useful
+  evidence but explicitly remains under development; raw Slidev Markdown must therefore be spiked,
+  not trusted by assertion.
+- [Weblate XLIFF 2 support](https://docs.weblate.org/en/latest/formats/xliff2.html) is likewise
+  documented as under development. Adapters must prove the exact profile they use and may prefer a
+  provider's native string API over file ingestion.

--- a/docs/decisions/0014-tms-architecture/adrs/0001-standalone-repository.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0001-standalone-repository.md
@@ -1,0 +1,31 @@
+# ADR 0001: Build a shared standalone localization hub
+
+- **Status:** proposed
+- **Scope:** ownership and repository boundary
+
+## Context
+
+Two workshops need the same extraction, synchronization, review, preview, and release behavior.
+Embedding the implementation in either workshop would couple its release cycle and content quirks to
+the other. Copying the tooling would immediately create two implementations of the drift problem.
+
+## Options considered
+
+- Build separately in each workshop: locally convenient, globally duplicated.
+- Put the implementation in one workshop and consume it from the other: creates accidental ownership
+  and biased fixtures.
+- Create one standalone product repository with workshop manifests and adapters: a deliberate shared
+  platform boundary.
+
+## Decision
+
+Create a standalone `workshop-localization-hub` repository. Workshop repositories contain English
+content, stable IDs, terminology, and a render manifest. The hub repository contains product code,
+contracts, fixtures, deployment definitions, and its own ADRs.
+
+## Consequences
+
+The hub can version independently and serve additional workshops. Cross-repository compatibility and
+release coordination become explicit responsibilities. The current workshop remains the place for
+ADR 0014 and integration acceptance, not for the platform implementation.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0002-build-vs-buy-boundary.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0002-build-vs-buy-boundary.md
@@ -1,0 +1,30 @@
+# ADR 0002: Integrate mature TMS products; do not build translator tooling
+
+- **Status:** proposed
+- **Scope:** product boundary
+
+## Context
+
+Translation editors, terminology, translation memory, reviewer assignment, machine-translation
+suggestions, and contributor management are mature TMS capabilities. Rebuilding them would delay the
+workshop-specific value and produce a less usable translator experience.
+
+## Options considered
+
+- Build a complete TMS: maximum control and unjustified product scope.
+- Use one TMS directly with repository scripts: quick, but provider-locked and weak on rendered
+  workshop review.
+- Build a control plane around external TMS products: focused custom behavior with mature editing.
+
+## Decision
+
+The hub will not implement a general translation editor, translation memory, glossary engine, or
+machine translation. It will integrate established TMS products and own content extraction,
+identity, provider-neutral workflow mapping, composition, rendered review, policy, and release.
+
+## Consequences
+
+Provider availability and API changes are dependencies. A conformance-tested adapter boundary and
+portable exports mitigate that risk. Translators retain mature interfaces while maintainers control
+workshop correctness.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0003-modular-monolith-and-workers.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0003-modular-monolith-and-workers.md
@@ -1,0 +1,28 @@
+# ADR 0003: Start with a modular monolith and isolated workers
+
+- **Status:** proposed
+- **Scope:** runtime decomposition
+
+## Context
+
+The system coordinates a strongly consistent workflow while also running expensive, failure-prone
+parsers and workshop builds. Premature microservices would multiply distributed-state and local-test
+cost without proven independent scaling needs.
+
+## Options considered
+
+- CI-only scripts: excellent first delivery mechanism, insufficient collaboration visibility.
+- Microservices per capability: flexible scaling, excessive operational and consistency burden.
+- Modular monolith plus asynchronous workers: cohesive domain transactions with isolated heavy jobs.
+
+## Decision
+
+Use one modular application/API backed by PostgreSQL and a durable queue. Run parsing, composition,
+rendering, and inspection in separately scalable workers, with rendering in hardened disposable
+sandboxes. Enforce module boundaries in code and architecture tests.
+
+## Consequences
+
+Local development and migrations remain approachable. The application is a deployment unit and must
+be designed for rolling upgrades. Modules may be extracted only after profiling demonstrates a need.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0004-canonical-model-and-xliff.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0004-canonical-model-and-xliff.md
@@ -1,0 +1,30 @@
+# ADR 0004: Use an internal canonical model and versioned XLIFF portability profiles
+
+- **Status:** proposed
+- **Scope:** localization data representation
+
+## Context
+
+The domain needs stable identities, source/context revisions, protected inline codes, review states,
+and portable provider integrations. A provider-native schema would leak throughout the product;
+invented YAML would discard decades of localization interoperability.
+
+## Options considered
+
+- Provider-native records: lowest first-adapter effort and strongest lock-in.
+- XLIFF as database schema: portable but awkward for domain queries and transitions.
+- Small canonical domain model with versioned XLIFF profiles for portable archive/import/export.
+
+## Decision
+
+Store a canonical localization model optimized for domain invariants. Define a lossless archival
+profile targeting XLIFF 2.1 for import/export, migrations, and recovery snapshots. Provider adapters
+may use native APIs or a separately declared supported XLIFF profile and must retain unsupported
+metadata in the hub. Validate each profile against published schemas plus project-specific
+Schematron/semantic rules.
+
+## Consequences
+
+Mappings and any profile downgrade must be tested. Portability, inline-code safety, metadata,
+workflow state, and future provider support improve. Archival XLIFF round-trip conformance becomes a
+release gate; provider feature claims remain adapter-conformance concerns.

--- a/docs/decisions/0014-tms-architecture/adrs/0005-explicit-content-identities.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0005-explicit-content-identities.md
@@ -1,0 +1,27 @@
+# ADR 0005: Require explicit immutable content identities
+
+- **Status:** proposed
+- **Scope:** slides and translation units
+
+## Context
+
+Paths, line numbers, text hashes, and slide ordinals change during ordinary authoring. Using them as
+identity loses translation memory, misapplies stale targets, or invalidates unrelated approvals.
+
+## Options considered
+
+- Source text as identity: convenient until the source changes.
+- Derived path/index identity: no author annotation, unstable on moves and insertions.
+- Explicit semantic IDs with source and structural hashes as revisions.
+
+## Decision
+
+Every localized slide and unit has an explicit immutable ID. Location is metadata. Source and
+structural-context hashes detect revisions. Renames require an alias migration checked for collisions
+and one-to-one history.
+
+## Consequences
+
+English authors add small identity annotations and CI rejects missing/duplicate IDs. Translation
+continuity survives file moves and insertions. Identity migrations are deliberate reviewable events.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0006-provider-adapter-contract.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0006-provider-adapter-contract.md
@@ -1,0 +1,27 @@
+# ADR 0006: Support multiple TMS products through a conformance-tested port
+
+- **Status:** proposed
+- **Scope:** external translation backends
+
+## Context
+
+The workshops want mature usability and scalability without permanent dependence on one provider.
+Provider APIs differ in workflow, IDs, screenshots, webhooks, exports, and rate limits.
+
+## Options considered
+
+- Select one provider and expose its model: simplest implementation, expensive exit.
+- Lowest-common-denominator abstraction: portable but discards useful capability.
+- Capability-negotiated port with mandatory conformance scenarios.
+
+## Decision
+
+Define a provider-neutral capability contract. Ship a deterministic simulator and at least two
+independent production adapters. Each adapter runs the same story-derived conformance suite locally
+and against a disposable live project. One provider is authoritative per workshop/locale.
+
+## Consequences
+
+Adapter work is higher, but lock-in and silent API drift decrease. Provider-specific enhancements are
+available only through declared capabilities, never through leaked domain types.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0007-generated-artifacts.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0007-generated-artifacts.md
@@ -1,0 +1,28 @@
+# ADR 0007: Keep English authoritative and publish generated locale artifacts
+
+- **Status:** proposed
+- **Scope:** source of truth and locale distribution
+
+## Context
+
+Facilitators need complete locale decks, labs, quizzes, and PDFs. Hand-maintained locale trees drift;
+runtime substitution is insufficient for deterministic export and slide splitting.
+
+## Options considered
+
+- Commit and hand-edit locale trees: familiar but unsafe.
+- Apply translations only at runtime: poor export and override behavior.
+- Generate immutable locale bundles from English, reviewed targets, and overrides.
+
+## Decision
+
+English workshop content remains authoritative. The hub composes locale source and delivery formats
+as content-addressed artifacts. Releases reference immutable source, target, override, toolchain, and
+review evidence. Generated files are never edited by hand.
+
+## Consequences
+
+Facilitators receive reproducible complete bundles. Artifact storage and retention become operational
+requirements. A later integration decision may expose generated-source pull requests for inspection,
+but those files remain derived output.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0008-governed-slide-overrides.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0008-governed-slide-overrides.md
@@ -1,0 +1,28 @@
+# ADR 0008: Permit governed, revision-bound slide overrides
+
+- **Status:** proposed
+- **Scope:** locale-specific structure
+
+## Context
+
+Translated text can overflow or require different pedagogical structure. Pure substitution cannot
+split a slide. Full locale trees solve layout by creating pervasive forks.
+
+## Options considered
+
+- Never permit structural differences: forces clipping or degraded prose.
+- Fork the entire locale deck: flexible and drift-prone.
+- Permit explicit replacement of one stable source slide with one or more locale slides.
+
+## Decision
+
+Overrides are first-class versioned objects bound to a source slide ID and source revision/hash. They
+require locale ownership, rationale, protected-content validation, linguistic review, visual review,
+and automatic invalidation on source change. The system reports override rates and repeated layout
+patterns.
+
+## Consequences
+
+Locales can remain readable without forking the library. Overrides are still small forks and impose
+review cost. High override concentration is treated as evidence to improve shared layouts.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0009-dual-human-approval.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0009-dual-human-approval.md
@@ -1,0 +1,29 @@
+# ADR 0009: Separate linguistic and visual approval and fail releases closed
+
+- **Status:** proposed
+- **Scope:** review and release policy
+
+## Context
+
+A correct translation can clip, overlap, lose animation meaning, or render with missing glyphs. A
+visually fitting slide can still contain incorrect language. Neither review substitutes for the
+other.
+
+## Options considered
+
+- TMS review alone: ignores rendered reality.
+- Automated layout checks alone: cannot judge language or pedagogy.
+- Separate linguistic and visual approvals bound to immutable inputs.
+
+## Decision
+
+Required units need authorized linguistic review; every release composition needs visual approval
+after structural and automated render gates. Approval binds to source, target, override, and render
+hashes. Release fails closed with stale, missing, fallback, or unapproved required content.
+
+## Consequences
+
+Shipping takes two explicit human judgments and provides defensible quality. Preview builds may use
+clearly watermarked fallback; released builds may not. Small teams may assign both roles to one
+person, but the audit record preserves both decisions.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0010-story-driven-test-architecture.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0010-story-driven-test-architecture.md
@@ -1,0 +1,29 @@
+# ADR 0010: Require multi-layer tests for every executable story
+
+- **Status:** proposed
+- **Scope:** test strategy and traceability
+
+## Context
+
+This product crosses parsers, asynchronous state, external providers, browser rendering, and release
+policy. Line coverage cannot show that a translator or facilitator outcome works, and end-to-end tests
+alone are slow and diagnostically weak.
+
+## Options considered
+
+- Conventional unit/integration tests without story traceability.
+- Mostly end-to-end tests: realistic but brittle and slow.
+- Executable stories bound to a deliberately layered test architecture.
+
+## Decision
+
+Every user story has domain acceptance, adapter conformance for every production TMS, and public
+interface end-to-end coverage, plus relevant property, visual, reliability, and security tests. CI
+generates a traceability report. Critical policy modules require complete branch coverage and targeted
+mutation testing.
+
+## Consequences
+
+Feature work includes meaningful test design up front. The suite is larger but failures localize
+better, adapters remain substitutable, and release evidence maps directly to user outcomes.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0011-idempotent-event-processing.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0011-idempotent-event-processing.md
@@ -1,0 +1,29 @@
+# ADR 0011: Use inbox/outbox processing and authoritative reconciliation
+
+- **Status:** proposed
+- **Scope:** asynchronous integration reliability
+
+## Context
+
+Git and TMS events can be duplicated, delayed, lost, or delivered out of order. Workers can fail
+between an external side effect and acknowledgement. Assuming exactly-once delivery creates silent
+divergence.
+
+## Options considered
+
+- Process webhooks immediately in delivery order: simple and incorrect under normal failures.
+- Poll every provider fully: reliable but slow and wasteful.
+- Durable inbox/outbox, idempotent commands, webhook-triggered cursor reconciliation.
+
+## Decision
+
+Persist and verify incoming envelopes before processing. Deduplicate by provider/event identity and
+payload digest. Use a transactional outbox for external commands and stable idempotency keys. Treat
+webhooks as hints; fetch authoritative changes through resumable provider cursors. Reconcile fully on
+demand and periodically.
+
+## Consequences
+
+The database and queue schema are more involved. Retries and replay become safe, ordering assumptions
+disappear, and operators can inspect a complete event timeline.
+

--- a/docs/decisions/0014-tms-architecture/adrs/0012-sandbox-untrusted-rendering.md
+++ b/docs/decisions/0014-tms-architecture/adrs/0012-sandbox-untrusted-rendering.md
@@ -1,0 +1,28 @@
+# ADR 0012: Treat parsing and rendering as untrusted execution
+
+- **Status:** proposed
+- **Scope:** security boundary for workshop content
+
+## Context
+
+The hub accepts repository archives and invokes repository-defined build tooling. Markdown/Vue
+parsing, package scripts, image decoders, browsers, and PDF exporters have large attack surfaces.
+Translation review does not establish code safety.
+
+## Options considered
+
+- Render inside application workers: operationally easy and unsafe.
+- Trust allow-listed repositories completely: compromised dependencies or pull requests still run.
+- Use disposable least-privilege sandboxes for parsing and rendering.
+
+## Decision
+
+Run parsers and renderers in ephemeral sandboxes with pinned images, non-root identity, read-only
+inputs/root filesystem, bounded temporary storage, resource/time/process limits, dropped privileges,
+no host socket, and denied network by default. Provide only short-lived artifact-upload capability.
+
+## Consequences
+
+Rendering infrastructure is more complex and some workshop builds need adaptation for offline use.
+The primary remote-code-execution boundary is explicit, testable, observable, and replaceable.
+

--- a/docs/decisions/0014-tms-architecture/adrs/README.md
+++ b/docs/decisions/0014-tms-architecture/adrs/README.md
@@ -1,0 +1,20 @@
+# Proposed ADRs for the standalone repository
+
+These ADRs belong in the future `workshop-localization-hub` repository if the architecture is
+accepted. They are kept here during exploration so the choices can be reviewed together. Their
+numbering is local to that proposed repository and does not extend the workshop's ADR sequence.
+
+| ADR | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-standalone-repository.md) | Build a shared standalone localization hub | proposed |
+| [0002](0002-build-vs-buy-boundary.md) | Integrate mature TMS products; do not build translator tooling | proposed |
+| [0003](0003-modular-monolith-and-workers.md) | Start with a modular monolith and isolated workers | proposed |
+| [0004](0004-canonical-model-and-xliff.md) | Use a canonical model and versioned XLIFF portability profiles | proposed |
+| [0005](0005-explicit-content-identities.md) | Require explicit immutable content identities | proposed |
+| [0006](0006-provider-adapter-contract.md) | Support multiple TMS products through a conformance-tested port | proposed |
+| [0007](0007-generated-artifacts.md) | Keep English authoritative and publish generated locale artifacts | proposed |
+| [0008](0008-governed-slide-overrides.md) | Permit governed, revision-bound slide overrides | proposed |
+| [0009](0009-dual-human-approval.md) | Separate linguistic and visual approval and fail releases closed | proposed |
+| [0010](0010-story-driven-test-architecture.md) | Require multi-layer tests for every executable story | proposed |
+| [0011](0011-idempotent-event-processing.md) | Use inbox/outbox processing and authoritative reconciliation | proposed |
+| [0012](0012-sandbox-untrusted-rendering.md) | Treat parsing and rendering as untrusted execution | proposed |

--- a/docs/decisions/0014-tms-architecture/delivery-plan.md
+++ b/docs/decisions/0014-tms-architecture/delivery-plan.md
@@ -1,0 +1,173 @@
+# Delivery plan
+
+The plan proves risk in descending order. It does not start with dashboards or a production
+deployment while the Slidev round trip remains unknown.
+
+## Delivery map
+
+```mermaid
+gantt
+  title Evidence-driven delivery sequence
+  dateFormat  YYYY-MM-DD
+  axisFormat  %b %d
+  section Foundations
+  Hostile corpus + identity contract       :a1, 2026-08-17, 14d
+  Lossless Slidev/lab/quiz adapters         :a2, after a1, 28d
+  section Portability
+  Canonical model + XLIFF round trip        :b1, after a1, 21d
+  TMS simulator + adapter conformance kit   :b2, after b1, 21d
+  section Providers
+  First live provider adapter               :c1, after b2, 21d
+  Independent second provider adapter       :c2, after c1, 21d
+  section Composition
+  Overrides + protected-content gates       :d1, after a2, 21d
+  Hermetic rendering + visual review        :d2, after d1, 28d
+  section Product
+  Workflow API, portal, and release bundles :e1, after d2, 28d
+  Two-workshop pilot and recovery drill     :e2, after c2, 28d
+```
+
+Dates are illustrative sequencing, not estimates or commitments.
+
+## Phase 0: decision fixtures
+
+Deliverables:
+
+- explicit slide/unit identity proposal;
+- a hostile corpus sampled from both workshops;
+- protected-term and protected-syntax contract;
+- executable stories for author, translator, reviewers, facilitator, and operator;
+- threat model; and
+- accepted ADRs for the standalone repository.
+
+Exit evidence:
+
+- the corpus includes every syntax construct used by either workshop;
+- every story maps to multiple planned test layers; and
+- maintainers agree on the visible user journeys before implementation.
+
+## Phase 1: local deterministic engine
+
+Build a CLI with no database or external provider dependency:
+
+```text
+hub inspect <workshop>
+hub extract <workshop> --out bundle.xlf
+hub compose <workshop> --locale de --targets bundle.xlf
+hub verify <composition>
+hub render <composition>
+hub impact <old-revision> <new-revision>
+```
+
+The CLI uses the final domain and content-adapter packages. It is not throwaway spike code.
+
+Exit evidence:
+
+- source-language round trip is semantically lossless;
+- protected skeletons cannot be mutated through target input;
+- German and Portuguese compositions build for the representative corpus;
+- override/split behavior is deterministic; and
+- parser property/fuzz tests run continuously.
+
+## Phase 2: TMS contract and first adapter
+
+Build the deterministic TMS simulator before a live adapter. The simulator exposes pagination,
+webhooks, review states, rate limits, failures, and controllable ordering.
+
+Exit evidence:
+
+- adapter contract runs identically against simulator and first live provider sandbox;
+- translation IDs and review state survive source edits, moves, obsolete units, and retries;
+- XLIFF export/import retains all required data; and
+- translators approve the editor context and deep-link journey.
+
+## Phase 3: independent second adapter
+
+The second adapter is an architecture test, not a checkbox. It should be implemented by someone who
+did not author the first adapter where practical, using only the contract and conformance kit.
+
+Exit evidence:
+
+- both adapters pass all mandatory live scenarios;
+- no provider-specific type appears outside adapter packages;
+- one locale migrates between providers through portable exports without identity loss; and
+- shadow comparison reports normalized behavioral differences.
+
+## Phase 4: service and collaboration UX
+
+Add PostgreSQL, durable queue, object storage, API, role-specific portal, and webhook ingestion around
+the proven engine.
+
+Exit evidence:
+
+- all CLI behaviors remain available and use the same application services;
+- author impact checks, translator links, linguistic state, visual review, and release dashboard work
+  end to end;
+- duplicate/out-of-order event tests and worker-kill tests pass; and
+- accessibility/usability sessions complete for each role.
+
+## Phase 5: hermetic rendering and release
+
+Exit evidence:
+
+- every click state of the representative locale decks is rendered;
+- structural and automated visual checks locate findings at slide/click coordinates;
+- human visual approval binds to exact render inputs;
+- incomplete or fallback-containing locales cannot publish;
+- release bundles reproduce from recorded inputs; and
+- rollback/withdrawal leaves an auditable replacement path.
+
+## Phase 6: two-workshop pilot
+
+```mermaid
+flowchart LR
+  W1["Workshop A<br/>de + pt-BR"]
+  W2["Workshop B<br/>de + pt-BR"]
+  Shared["Shared glossary + translation memory"]
+  Separate["Separate source revisions, policy, previews, releases"]
+  Providers["Both supported TMS adapters"]
+
+  W1 & W2 --> Shared
+  W1 & W2 --> Separate
+  Separate --> Providers
+```
+
+The pilot must exercise both workshops, two locales, both TMS adapters, normal catalog composition,
+at least one slide split, and one provider migration rehearsal.
+
+Exit evidence:
+
+- facilitators run released locale bundles without hub/operator assistance;
+- a real English change produces correct selective invalidation;
+- terminology reuse is visible across workshops without leaking workflow state;
+- a full backup restore reproduces a released artifact;
+- operating SLOs and alert runbooks are demonstrated; and
+- maintainers explicitly decide whether the usability warrants production adoption.
+
+## Go/no-go checkpoints
+
+| Checkpoint | Stop or redesign when… |
+| --- | --- |
+| Parser | real Slidev syntax cannot round-trip without frequent source rewrites |
+| Translator UX | protected syntax or fragmented strings make normal translation unsafe |
+| Override model | overrides become common enough to constitute a locale fork |
+| Provider portability | required state/inline codes cannot survive both adapters |
+| Visual QA | automated findings are too noisy to guide reviewers |
+| Operations | recovery cannot reproduce a historical release |
+| Product UX | facilitators or translators require repository internals for routine work |
+
+## Initial backlog by user outcome
+
+| Epic | First demonstrable story |
+| --- | --- |
+| Source intake | An author sees which reviewed German units become stale before merging English |
+| Translation | A translator edits prose with code protected and opens the source screenshot in one click |
+| Linguistic review | A reviewer accepts a target and the hub imports one normalized state change |
+| Composition | A reviewed German target produces valid Slidev without changing fenced YAML |
+| Overrides | A reviewer splits one crowded German slide and sees both target slides rendered |
+| Visual review | A reviewer sees clipping coordinates and approves the exact corrected composition |
+| Release | A facilitator downloads one verified locale bundle with zero fallback units |
+| Multi-provider | The same source-change story passes against both TMS adapters |
+| Recovery | An operator replays duplicate/out-of-order events with no duplicate semantic change |
+| Portability | A locale migrates between providers without losing stable identities or accepted targets |
+

--- a/docs/decisions/0014-tms-architecture/domain-model-and-contracts.md
+++ b/docs/decisions/0014-tms-architecture/domain-model-and-contracts.md
@@ -1,0 +1,270 @@
+# Domain model and contracts
+
+## Canonical model
+
+The hub uses a small canonical localization model (CLM) internally and a versioned XLIFF profile for
+portable archive/import/export. The CLM is optimized for domain logic. An adapter may map the CLM to
+a provider's native string API or to the exact interchange profile that provider supports; provider
+format limitations do not weaken the canonical model.
+
+```mermaid
+erDiagram
+  WORKSHOP ||--o{ SOURCE_REVISION : has
+  WORKSHOP ||--o{ LOCALE : enables
+  SOURCE_REVISION ||--|{ RESOURCE : contains
+  RESOURCE ||--|{ UNIT_REVISION : contains
+  UNIT_IDENTITY ||--o{ UNIT_REVISION : versions
+  UNIT_REVISION ||--o{ TARGET_REVISION : translated_as
+  LOCALE ||--o{ TARGET_REVISION : owns
+  TARGET_REVISION ||--o{ REVIEW : receives
+  SOURCE_REVISION ||--o{ OVERRIDE_REVISION : invalidates
+  LOCALE ||--o{ OVERRIDE_REVISION : owns
+  SOURCE_REVISION ||--o{ COMPOSITION : composes
+  LOCALE ||--o{ COMPOSITION : selects
+  COMPOSITION ||--o{ RENDER : produces
+  RENDER ||--o{ VISUAL_REVIEW : receives
+  COMPOSITION ||--o| RELEASE : becomes
+
+  WORKSHOP {
+    string id PK
+    string source_language
+  }
+  SOURCE_REVISION {
+    uuid id PK
+    string git_sha
+    string manifest_hash
+  }
+  UNIT_IDENTITY {
+    string id PK
+    string role
+  }
+  UNIT_REVISION {
+    uuid id PK
+    string source_hash
+    string structural_context_hash
+  }
+  TARGET_REVISION {
+    uuid id PK
+    string target_hash
+    string linguistic_state
+  }
+  COMPOSITION {
+    uuid id PK
+    string content_hash
+    string policy_result
+  }
+  RELEASE {
+    string version PK
+    string provenance_digest
+  }
+```
+
+## Identity hierarchy
+
+```text
+workshop:kubernetes-practitioner
+└── resource:pages/S07-service/index.md
+    └── slide:S07.service-types
+        ├── unit:kicker
+        ├── unit:title
+        ├── unit:card.cluster-ip.heading
+        ├── unit:card.cluster-ip.body
+        └── unit:speaker-note.mental-model
+```
+
+Rules:
+
+1. IDs are explicit, semantic, immutable, and unique inside a workshop.
+2. File paths and ordinal positions are mutable locations, never identities.
+3. A source hash detects text change; it is not the unit ID.
+4. A structural-context hash detects changes that may affect meaning or layout even when text does
+   not change—for example a card moving to a more constrained layout.
+5. Renaming an ID is an explicit migration with an alias, never delete-and-recreate.
+6. A deleted unit becomes obsolete but remains queryable for translation-memory provenance.
+
+## Unit shape
+
+```yaml
+apiVersion: localization.workshops.dev/v1alpha1
+kind: LocalizationUnit
+metadata:
+  workshop: kubernetes-practitioner
+  resource: pages/S07-service/index.md
+  slide: S07.service-types
+  id: card.cluster-ip.body
+spec:
+  role: prose
+  sourceLanguage: en
+  source: >-
+    A stable in-cluster virtual IP. Reachable only from inside the cluster.
+  sourceHash: sha256:...
+  structuralContextHash: sha256:...
+  context:
+    layout: default
+    component: KwCard
+    headingUnit: card.cluster-ip.heading
+    screenshot: artifact://sha256/...
+  inlineCodes:
+    - token: p1
+      source: <strong>in-cluster</strong>
+      canDelete: false
+      canReorder: true
+  constraints:
+    protectedTerms: [ClusterIP]
+    sizeHint:
+      sourceRenderedWidthPx: 284
+      targetBudgetRatio: 1.35
+```
+
+Portable interchange should use XLIFF inline-code and metadata facilities instead of embedding this
+illustrative YAML in provider projects. Provider adapters must document and test any downgraded or
+native representation.
+
+## Translation state
+
+Provider-specific states are normalized into a strict hub state machine.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Missing
+  Missing --> Draft: target imported
+  Draft --> NeedsEditing: submitted
+  NeedsEditing --> LinguisticallyReviewed: accepted by authorized reviewer
+  LinguisticallyReviewed --> StructurallyValid: composition gates pass
+  StructurallyValid --> VisuallyReviewed: locale reviewer accepts render
+  VisuallyReviewed --> Releasable: all release policy checks pass
+  Releasable --> Released: immutable publication
+
+  Draft --> Stale: source/context changes
+  NeedsEditing --> Stale: source/context changes
+  LinguisticallyReviewed --> Stale: semantic source change
+  StructurallyValid --> Stale: source or structure changes
+  VisuallyReviewed --> Stale: source, composition, or render profile changes
+  Stale --> NeedsEditing: translator revalidates
+```
+
+`Released` is immutable. A correction produces a new release; audit history is never rewritten.
+
+## Change classification
+
+Not every English edit should destroy all approval, but preserving approval must be conservative.
+
+| Change | Translation state | Visual state |
+| --- | --- | --- |
+| Whitespace-only outside protected syntax | Preserve | Preserve if composed hash unchanged |
+| Source location/file move with same explicit ID | Preserve | Preserve if render inputs unchanged |
+| Punctuation or prose edit | Needs editing | Invalidate |
+| Protected code change | Needs editing or policy-defined carry-forward | Invalidate |
+| Layout/component/context change | Preserve language provisionally | Invalidate visual approval |
+| Unit split/join | Needs editing; offer translation-memory candidates | Invalidate |
+| Slide override source anchor changes | Mark entire override stale | Invalidate |
+| Render toolchain/profile changes | Preserve language | Invalidate visual approval |
+
+The first version should classify only exact-equal versus changed. Smarter semantic classification can
+be introduced after false-preservation tests demonstrate safety.
+
+## Protected-content model
+
+```mermaid
+flowchart LR
+  Source["Source syntax tree"]
+  Mark["Mark translatable and protected nodes"]
+  Skeleton["Structural skeleton + protected-token digest"]
+  Target["Imported target units"]
+  Reinsert["Reinsert into cloned source tree"]
+  Compare["Compare skeleton and protected digest"]
+  Result{"Exact invariants?"}
+
+  Source --> Mark --> Skeleton
+  Mark --> Target --> Reinsert --> Compare
+  Skeleton --> Compare --> Result
+```
+
+Protected content includes:
+
+- fenced code blocks and their info strings;
+- inline code unless explicitly marked translatable;
+- component names, prop names, directives, expressions, and event handlers;
+- frontmatter keys and non-translatable values;
+- URLs, image references, file paths, flags, resource names, and quiz answer IDs;
+- slide separators, imports, click sequencing, and conditional structure.
+
+“Byte-identical” applies where the parser can preserve raw source slices. The stronger system-level
+invariant is that the protected token sequence and syntax skeleton are identical after composition.
+
+## Override model
+
+An override is a versioned replacement of one source slide by one or more locale slides.
+
+```yaml
+apiVersion: localization.workshops.dev/v1alpha1
+kind: SlideOverride
+metadata:
+  workshop: kubernetes-practitioner
+  locale: de
+  sourceSlideId: S00.statement-why
+spec:
+  reason: overflow
+  sourceRevision: 8f31c2...
+  sourceSlideHash: sha256:...
+  protectedBlockPolicy: ordered-equivalent
+  fragment: i18n/de/overrides/S00.statement-why.md
+  owner: locale-team-de
+  expiresAfterSourceChange: true
+```
+
+```mermaid
+flowchart TB
+  Slide["Source slide"]
+  Exists{"Current override?"}
+  Normal["Catalog substitution"]
+  Override["Override fragment"]
+  Anchor["Validate source anchor"]
+  Protected["Validate protected block policy"]
+  Emit["Emit 1..n target slides"]
+
+  Slide --> Exists
+  Exists -->|No| Normal --> Emit
+  Exists -->|Yes| Override --> Anchor --> Protected --> Emit
+```
+
+Override health is a first-class metric. A locale exceeding a configurable override ratio is not
+blocked automatically, but the system opens an architecture warning because the catalog model may
+no longer be the dominant path.
+
+## Release manifest
+
+```json
+{
+  "schemaVersion": 1,
+  "workshop": "kubernetes-practitioner",
+  "locale": "de",
+  "release": "2026.08.15-de.1",
+  "sourceRevision": "8f31c2...",
+  "compositionDigest": "sha256:...",
+  "renderProfileDigest": "sha256:...",
+  "artifacts": {
+    "interactiveDeck": "sha256:...",
+    "pdf": "sha256:...",
+    "labs": "sha256:...",
+    "quiz": "sha256:..."
+  },
+  "evidence": {
+    "linguisticReview": "sha256:...",
+    "structuralReport": "sha256:...",
+    "visualReview": "sha256:..."
+  },
+  "fallbackUnits": 0,
+  "issuedAt": "2026-08-15T00:00:00Z"
+}
+```
+
+## API principles
+
+- Commands require idempotency keys and return operation resources for asynchronous work.
+- Events are append-only facts with globally unique IDs.
+- All writes use optimistic concurrency.
+- Every response carrying mutable state includes its source revision and entity version.
+- Pagination is cursor-based and ordering deterministic.
+- Provider payloads never leak into the domain API; adapter diagnostics are linked separately.
+- Schemas are versioned, machine-readable, and compatibility-tested.

--- a/docs/decisions/0014-tms-architecture/integration-architecture.md
+++ b/docs/decisions/0014-tms-architecture/integration-architecture.md
@@ -1,0 +1,228 @@
+# Integration architecture
+
+## Ports and adapters
+
+```mermaid
+flowchart LR
+  Domain["Hub domain"]
+  Contract["TMS port"]
+  Fake["Deterministic fake"]
+  TMS1["Weblate adapter"]
+  TMS2["Crowdin adapter"]
+  Future["Future adapter"]
+
+  Domain --> Contract
+  Contract --> Fake & TMS1 & TMS2 & Future
+  Conformance["Shared conformance suite"] --> Fake & TMS1 & TMS2 & Future
+```
+
+The provider-neutral port represents capabilities, not one provider's resource model.
+
+```ts
+interface TranslationBackend {
+  capabilities(): Promise<BackendCapabilities>
+  ensureWorkspace(input: WorkspaceSpec): Promise<WorkspaceRef>
+  publishSource(input: SourceBundle, key: IdempotencyKey): Promise<PublishResult>
+  archiveSource(input: ArchiveRequest, key: IdempotencyKey): Promise<void>
+  importReviewedTargets(cursor: ChangeCursor): AsyncIterable<TargetChange>
+  getUnitLink(identity: UnitIdentity, locale: Locale): Promise<URL | undefined>
+  mapWorkflowState(remote: RemoteState): NormalizedLinguisticState
+  verifyWebhook(request: SignedRequest): Promise<VerifiedBackendEvent>
+  health(): Promise<BackendHealth>
+}
+```
+
+No code outside an adapter may use remote project IDs, status names, pagination tokens, rate-limit
+headers, or webhook payloads.
+
+## Capability negotiation
+
+Providers differ. Pretending otherwise produces a leaky abstraction. An adapter declares support:
+
+```yaml
+workflow:
+  linguisticReview: native
+  sourceReview: native
+  customStates: emulated
+interchange:
+  xliff21: native
+  stableExternalIds: native
+  inlineCodes: native
+context:
+  screenshots: native
+  deepLinks: native
+automation:
+  webhooks: native
+  incrementalPull: native
+  idempotentUpload: emulated
+```
+
+The workshop policy states required capabilities. Connection setup fails early if the selected
+adapter cannot meet them. Emulated capabilities must be covered by the same conformance scenarios as
+native ones.
+
+## Synchronization protocol
+
+```mermaid
+sequenceDiagram
+  participant Hub
+  participant Outbox as Transactional outbox
+  participant Adapter
+  participant TMS
+  participant Inbox as Event inbox
+
+  Hub->>Outbox: Commit SourceRevisionAccepted + publish command
+  Outbox->>Adapter: Deliver command with idempotency key
+  Adapter->>TMS: Upsert source bundle
+  TMS-->>Adapter: Remote revision
+  Adapter-->>Outbox: Record completion
+  TMS->>Inbox: Signed webhook
+  Inbox->>Inbox: Verify, deduplicate, persist raw envelope
+  Inbox->>Adapter: Normalize event
+  Adapter->>TMS: Fetch authoritative changed targets
+  Adapter-->>Hub: Reviewed TargetChanges + cursor
+  Hub->>Hub: Apply with optimistic concurrency
+```
+
+Webhooks are hints, not authoritative state. They trigger a pull using a durable cursor. This handles
+lost, duplicate, delayed, and out-of-order delivery without trusting webhook order.
+
+## Two-provider modes
+
+```mermaid
+flowchart TB
+  Policy{"Connection mode"}
+  Primary["Primary<br/>read + write"]
+  Shadow["Shadow<br/>write + compare, no release authority"]
+  Migration["Migration<br/>freeze writes, export/import, verify"]
+  Split["Portfolio split<br/>different workshops use different providers"]
+
+  Policy --> Primary & Shadow & Migration & Split
+```
+
+- **Primary:** normal production operation with one authoritative provider per workshop/locale.
+- **Shadow:** publish a synthetic or consented corpus to a second adapter and compare normalized
+  behavior; never merge target translations from two providers.
+- **Migration:** use XLIFF and translation-memory exports, freeze provider writes briefly, import,
+  reconcile every identity and review state, then change authority.
+- **Portfolio split:** the two workshops may select different providers while sharing the same hub.
+
+Dual-writing live translator edits to two independent TMS products is intentionally unsupported. It
+creates irreconcilable concurrent sources of truth and a hostile translator experience.
+
+## Workshop source integration
+
+```mermaid
+sequenceDiagram
+  participant Repo as Workshop CI
+  participant Hub
+  participant Store as Object store
+  participant Parser
+
+  Repo->>Repo: Build source bundle from exact commit
+  Repo->>Hub: POST manifest + commit + bundle digest
+  Hub->>Store: Fetch/verify immutable bundle
+  Hub->>Parser: Parse in isolated worker
+  Parser-->>Hub: Units + syntax skeleton + diagnostics
+  Hub-->>Repo: Check result and localization impact URL
+```
+
+The hub does not clone arbitrary pull-request URLs with broad credentials. Workshop CI uploads or
+authorizes an immutable archive, and the hub verifies repository, commit, manifest, and digest.
+
+## Content adapters
+
+```mermaid
+flowchart TB
+  Bundle["Workshop source bundle"]
+  Router{"Surface type"}
+  Slidev["Slidev adapter<br/>multi-frontmatter + Vue islands"]
+  Labs["Lab Markdown adapter<br/>headings + prose + fences"]
+  Quiz["Quiz JSON adapter<br/>schema-aware fields"]
+  CLM["Canonical localization units"]
+  Skeleton["Protected syntax skeleton"]
+
+  Bundle --> Router
+  Router --> Slidev & Labs & Quiz
+  Slidev --> CLM & Skeleton
+  Labs --> CLM & Skeleton
+  Quiz --> CLM & Skeleton
+```
+
+All adapters implement the same lifecycle:
+
+1. `detect` whether the resource is supported;
+2. `extract` units plus raw protected slices;
+3. `validate` explicit identity and authoring contract;
+4. `compose` reviewed target units into a clone of the source syntax tree;
+5. `assertInvariants` against the recorded skeleton;
+6. `serialize` deterministically; and
+7. `explain` any diagnostic with source location and remediation.
+
+## XLIFF boundary
+
+```mermaid
+flowchart LR
+  CLM["Canonical model"]
+  XLIFF["Portable XLIFF bundle"]
+  Adapter["Provider adapter"]
+  Native["Provider-native project"]
+  Export["Portable export"]
+
+  CLM --> XLIFF --> Adapter --> Native
+  Native --> Adapter --> XLIFF --> CLM
+  XLIFF --> Export
+```
+
+XLIFF is the archival interchange and escape hatch, not the domain database and not necessarily the
+provider upload format. The portable profile targets XLIFF 2.1; an adapter may use a provider-native
+API or a proven provider-supported XLIFF subset. It must prove semantic round trips for IDs, inline
+codes, source revisions, target text, normalized state, notes, and context links. Unsupported
+portable metadata stays in the hub and must not silently disappear.
+
+## Rendering contract
+
+Each workshop supplies a pinned, containerized render profile:
+
+```yaml
+apiVersion: localization.workshops.dev/v1alpha1
+kind: RenderProfile
+spec:
+  image: registry.example/workshop-renderer@sha256:...
+  commands:
+    validate: ["pnpm", "localization:validate"]
+    build: ["pnpm", "build:localized"]
+    export: ["pnpm", "export:localized"]
+  outputs:
+    interactive: dist/**
+    pdf: dist-pdf/**
+    screenshots: dist-render/**
+  limits:
+    cpu: "4"
+    memory: 8Gi
+    timeout: 20m
+    network: none
+```
+
+```mermaid
+sequenceDiagram
+  participant Hub
+  participant Sandbox
+  participant Inspector
+  participant Store
+
+  Hub->>Sandbox: Source + composition + pinned profile
+  Sandbox->>Sandbox: Validate, build, export, screenshot
+  Sandbox->>Store: Upload outputs + logs + manifest
+  Store-->>Inspector: Content-addressed evidence
+  Inspector->>Inspector: Clipping, overlap, missing glyph, structure checks
+  Inspector-->>Hub: Findings with slide/click coordinates
+```
+
+## Versioning
+
+- Workshop manifests, CLM records, events, and API payloads carry explicit schema versions.
+- Adapters declare the hub contract versions they implement.
+- Additive changes are preferred; breaking changes require parallel readers and a migration fixture.
+- Stored raw provider envelopes remain readable by the adapter version that accepted them.
+- Release artifacts record all schema and tool versions needed for reproduction.

--- a/docs/decisions/0014-tms-architecture/operations-and-security.md
+++ b/docs/decisions/0014-tms-architecture/operations-and-security.md
@@ -1,0 +1,204 @@
+# Operations and security
+
+## Service objectives
+
+The hub is not on the live presentation request path, so correctness and recoverability take
+precedence over millisecond latency.
+
+| Indicator | Initial objective |
+| --- | --- |
+| Accepted source revision visible in dashboard | 99% within 10 minutes |
+| Reviewed provider change imported | 99% within 15 minutes |
+| Duplicate event causes duplicate semantic change | 0 |
+| Released artifact reproducible from recorded inputs | 100% sampled releases |
+| Incorrectly released stale/unreviewed required unit | 0 |
+| API availability | 99.9% monthly |
+| Recovery point objective | 15 minutes |
+| Recovery time objective | 4 hours |
+
+## Trust boundaries
+
+```mermaid
+flowchart TB
+  subgraph Public["Public/untrusted"]
+    User["Browser/CLI"]
+    Webhook["Provider webhook"]
+    Source["Workshop source archive"]
+  end
+  subgraph Control["Control plane"]
+    Ingress["Authenticated ingress"]
+    App["Application"]
+    DB[("State database")]
+    Queue[("Queue")]
+  end
+  subgraph Sandbox["Untrusted execution boundary"]
+    Parser["Parser job"]
+    Renderer["Repository render job"]
+  end
+  subgraph External["External services"]
+    TMS["TMS API"]
+    Git["Git provider"]
+    Store["Artifact store"]
+  end
+
+  User --> Ingress
+  Webhook --> Ingress
+  Source --> Ingress
+  Ingress --> App --> DB & Queue
+  Queue --> Parser & Renderer
+  App --> TMS & Git & Store
+  Parser & Renderer --> Store
+```
+
+Repository content, translation targets, XLIFF payloads, provider events, archives, and render scripts
+are untrusted input. Linguistic review does not make content safe to execute.
+
+## Authorization
+
+| Action | Author | Translator | Linguistic reviewer | Visual reviewer | Operator | Release manager |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Submit source revision | Yes | No | No | No | Yes | No |
+| Edit translation | In TMS policy | Yes | Yes | No | No | No |
+| Accept linguistic review | No | No | Yes | No | No | No |
+| Approve visual composition | No | No | Optional | Yes | No | No |
+| Replay failed job | No | No | No | No | Yes | No |
+| Change provider connection | No | No | No | No | Yes | No |
+| Publish release | No | No | No | No | Emergency only | Yes |
+
+Separation of duties is configurable for small communities, but the audit log must show when one
+person holds multiple roles. Service identities receive narrower permissions than people.
+
+## Secret and credential model
+
+- Prefer workload identity/OIDC over stored cloud credentials.
+- Use installation-scoped Git app tokens, not personal access tokens.
+- Use separate TMS credentials per environment and adapter.
+- Fetch secrets just in time; never place them in job payloads or artifacts.
+- Redact known token formats and provider payload authorization fields from telemetry.
+- Rotate without downtime by supporting overlapping credential versions.
+- Test revoked, expired, under-scoped, and over-scoped credentials.
+
+## Render isolation
+
+```mermaid
+flowchart LR
+  Input["Verified source + locale bundle"]
+  Job["Disposable sandbox"]
+  RO["Read-only input mount"]
+  Tmp["Bounded temporary filesystem"]
+  Net["No network by default"]
+  Output["Allow-listed outputs"]
+  Destroy["Destroy sandbox"]
+
+  Input --> RO --> Job
+  Tmp --> Job
+  Net --> Job
+  Job --> Output --> Destroy
+```
+
+Jobs run as non-root with a read-only root filesystem, dropped capabilities, resource quotas,
+deadline, process limit, seccomp policy, and no host/container socket. Dependencies are prebuilt into
+the pinned renderer image. Exceptions to network denial are explicit per render profile and logged.
+
+## Event reliability
+
+```mermaid
+stateDiagram-v2
+  [*] --> Received
+  Received --> Verified
+  Received --> Rejected: invalid signature/schema
+  Verified --> Deduplicated
+  Deduplicated --> Applied
+  Deduplicated --> Retryable: transient dependency failure
+  Retryable --> Deduplicated: scheduled retry
+  Retryable --> DeadLetter: retry budget exhausted
+  DeadLetter --> Deduplicated: operator replay
+  Applied --> [*]
+  Rejected --> [*]
+```
+
+Raw event envelopes are retained for a bounded period with sensitive fields redacted or encrypted.
+The inbox records provider, event ID, payload digest, received time, signature result, processing
+attempts, normalized outcome, and correlation ID.
+
+## Observability
+
+```mermaid
+flowchart TB
+  Signal["Logs · metrics · traces · audit events"]
+  Correlate["workshop · locale · source revision · operation · adapter"]
+  Dash["Dashboards"]
+  Alert["SLO and invariant alerts"]
+  Audit["Tamper-evident audit archive"]
+
+  Signal --> Correlate --> Dash & Alert & Audit
+```
+
+Required dashboards:
+
+- source-ingestion latency and failures;
+- provider sync lag, rate limits, cursor age, and webhook verification failures;
+- translation state and staleness by workshop/locale;
+- queue depth, retries, dead letters, and oldest job;
+- composition/structural/visual failures by content construct and layout;
+- render duration, resource use, and sandbox violations;
+- release readiness and evidence age; and
+- adapter conformance recency.
+
+Alerts identify an operator action. “Translation incomplete” is product state, not an incident.
+
+## Backup, restore, and disaster recovery
+
+```mermaid
+flowchart LR
+  DB["Continuous DB backup"]
+  Objects["Versioned replicated objects"]
+  Config["Git-versioned configuration"]
+  Restore["Isolated restore environment"]
+  Verify["Consistency + sample reproduction"]
+  Promote["Documented recovery decision"]
+
+  DB & Objects & Config --> Restore --> Verify --> Promote
+```
+
+- PostgreSQL uses point-in-time recovery and encrypted backups.
+- Object storage uses versioning, retention, and cross-failure-domain replication.
+- TMS exports and XLIFF portability snapshots run regularly; a provider is not the sole copy.
+- Restore drills occur at least quarterly and before major storage migrations.
+- A drill reproduces one historical locale release, not merely “database started successfully.”
+
+## Release integrity
+
+Release publication is a two-phase operation:
+
+1. assemble all artifacts and evidence under a temporary immutable prefix;
+2. verify digests, policy, provenance, and visibility;
+3. atomically publish a small release pointer/manifest; and
+4. sign or attest the manifest using the release identity.
+
+The public release index reads only published manifests, so a failed upload cannot expose a partial
+workshop.
+
+## Data retention and privacy
+
+- Translation content and public contributor identity may be long-lived project records.
+- Authentication events, IP addresses, and raw webhook payloads have shorter documented retention.
+- Avoid storing provider profiles when a stable external subject ID suffices.
+- Support contributor attribution/license requirements without copying unnecessary personal data.
+- Deletion/anonymization workflows preserve the integrity of released artifacts and audit decisions.
+
+## Runbook minimums
+
+Before production, operators need tested runbooks for:
+
+- provider outage or API incompatibility;
+- webhook-signing-key rotation;
+- stuck cursor and full reconciliation;
+- dead-letter inspection and replay;
+- corrupt or malicious source bundle;
+- renderer sandbox violation;
+- database restore and object reconciliation;
+- accidental source revision publication;
+- compromised integration credential; and
+- withdrawal/replacement of a faulty locale release.
+

--- a/docs/decisions/0014-tms-architecture/system-architecture.md
+++ b/docs/decisions/0014-tms-architecture/system-architecture.md
@@ -1,0 +1,206 @@
+# System architecture
+
+## Product boundary
+
+The localization hub is a control plane between workshop repositories, one or more external TMS
+products, and deterministic renderers. It stores orchestration state and evidence; it does not own
+English authoring or provide the primary translation editor.
+
+```mermaid
+C4Context
+  title System context
+  Person(author, "Workshop author", "Edits English Markdown and JSON")
+  Person(translator, "Translator", "Translates in familiar TMS UI")
+  Person(reviewer, "Locale reviewer", "Approves language and rendered layout")
+  Person(facilitator, "Facilitator", "Downloads a released locale snapshot")
+  System(hub, "Workshop Localization Hub", "Coordinates extraction, sync, preview, policy, and release")
+  System_Ext(git, "Workshop repositories", "English source and build contract")
+  System_Ext(tms, "External TMS products", "Translation memory, glossary, editor, linguistic workflow")
+  System_Ext(ci, "CI and renderer fleet", "Hermetic validation, Slidev builds, PDFs, screenshots")
+  System_Ext(store, "Artifact registry", "Immutable bundles, evidence, and provenance")
+
+  Rel(author, git, "Commits English content")
+  Rel(git, hub, "Source revision event and content bundle")
+  Rel(translator, tms, "Translates")
+  Rel(reviewer, tms, "Linguistic review")
+  Rel(hub, tms, "Syncs units and review state")
+  Rel(hub, ci, "Requests isolated validation")
+  Rel(ci, store, "Writes render evidence")
+  Rel(hub, store, "Publishes signed locale release")
+  Rel(reviewer, hub, "Visual approval")
+  Rel(facilitator, store, "Downloads approved release")
+```
+
+## Container view
+
+```mermaid
+flowchart TB
+  subgraph Edge["User and automation interfaces"]
+    Web["Web portal"]
+    CLI["CLI"]
+    Hook["Webhook/API ingress"]
+  end
+
+  subgraph App["Modular application"]
+    API["Application API"]
+    Ingest["Source ingestion"]
+    Model["Canonical localization model"]
+    Workflow["Workflow and policy engine"]
+    Sync["TMS synchronization"]
+    Compose["Locale composer"]
+    Release["Release coordinator"]
+  end
+
+  subgraph Workers["Isolated workers"]
+    Parse["Parser/extractor workers"]
+    Render["Renderer workers"]
+    Inspect["Visual/structural inspectors"]
+  end
+
+  DB[(PostgreSQL)]
+  Queue[(Durable queue)]
+  Objects[(Object store)]
+  TMSA["TMS adapter A"]
+  TMSB["TMS adapter B"]
+  Git["Git provider adapter"]
+
+  Web --> API
+  CLI --> API
+  Hook --> API
+  API --> Ingest & Workflow & Sync & Release
+  Ingest --> Model
+  Sync --> TMSA & TMSB
+  App --> DB
+  App --> Queue
+  Queue --> Parse & Render & Inspect
+  Parse --> Objects
+  Compose --> Objects
+  Render --> Objects
+  Inspect --> Objects
+  Ingest --> Git
+```
+
+### Why a modular monolith
+
+The hard problem is correctness across a state machine, not independent scaling of dozens of
+services. One deployable application keeps transactions, migrations, local development, and tracing
+comprehensible. CPU- and memory-heavy parsing/rendering run in isolated workers so they can scale and
+fail independently. Module boundaries are enforced in code and tests; they can become services only
+after measured pressure justifies it.
+
+## Source-to-release pipeline
+
+```mermaid
+flowchart LR
+  Commit["English commit"]
+  Manifest["Validate workshop manifest"]
+  Extract["Parse into lossless syntax trees"]
+  CLM["Build canonical units"]
+  Diff["Semantic diff against prior revision"]
+  Push["Push changed units"]
+  Translate["Translate and review in TMS"]
+  Pull["Import reviewed targets"]
+  Compose["Compose locale source + overrides"]
+  Verify["Structural and terminology gates"]
+  Render["Build decks, labs, quiz, PDFs"]
+  Visual["Automated + human visual review"]
+  Publish["Publish immutable release"]
+
+  Commit --> Manifest --> Extract --> CLM --> Diff --> Push --> Translate --> Pull --> Compose
+  Compose --> Verify --> Render --> Visual --> Publish
+```
+
+Every box consumes immutable input and produces a content-addressed output. Retrying a stage with
+the same inputs must produce the same semantic result. Side effects use idempotency keys.
+
+## Repository topology
+
+The code should live outside either workshop repository:
+
+```text
+workshop-localization-hub/
+├── apps/
+│   ├── api/                 # HTTP API and webhook ingress
+│   ├── web/                 # operator/reviewer portal
+│   ├── worker/              # parser, composer, renderer orchestration
+│   └── cli/                 # local and CI entrypoint
+├── packages/
+│   ├── domain/              # entities, state machine, policies
+│   ├── content-slidev/      # lossless Slidev adapter
+│   ├── content-markdown/    # lab adapter
+│   ├── content-quiz-json/   # quiz adapter
+│   ├── interchange-xliff/   # portable XLIFF archive/import/export profiles
+│   ├── tms-contract/        # provider-neutral port + conformance kit
+│   ├── tms-weblate/         # first independent adapter
+│   ├── tms-crowdin/         # second independent adapter
+│   ├── git-contract/        # Git provider port
+│   ├── render-contract/     # hermetic workshop build protocol
+│   └── test-corpus/         # adversarial and real-world fixtures
+├── features/                # executable user stories
+├── deploy/                  # reproducible deployment definitions
+├── docs/                    # architecture, operations, and ADRs
+└── tools/                   # migration and fixture tooling
+```
+
+Workshop repositories contain only a small declarative contract:
+
+```yaml
+# .localization/workshop.yaml
+apiVersion: localization.workshops.dev/v1alpha1
+kind: WorkshopLocalization
+metadata:
+  id: kubernetes-practitioner
+spec:
+  sourceLanguage: en
+  locales: [de, pt-BR]
+  surfaces:
+    - type: slidev
+      include: pages/**/index.md
+    - type: lab-markdown
+      include: labs/**/*.md
+    - type: quiz-json
+      include: quiz/questions.json
+  protectedTerms: .localization/terminology.yaml
+  renderProfile: .localization/render.yaml
+```
+
+## Deployment view
+
+```mermaid
+flowchart TB
+  Internet["Users and provider webhooks"]
+  Gateway["TLS ingress + WAF/rate limits"]
+  API["Stateless application replicas"]
+  Worker["General workers"]
+  Render["Ephemeral sandboxed render jobs"]
+  DB[("Managed PostgreSQL<br/>multi-AZ + PITR")]
+  Queue[("Durable queue")]
+  Store[("Versioned object storage")]
+  Secrets["Workload identity / secret manager"]
+  Obs["Logs · metrics · traces · audit stream"]
+
+  Internet --> Gateway --> API
+  API --> DB & Queue & Store
+  Queue --> Worker & Render
+  Worker --> DB & Store
+  Render --> Store
+  API & Worker & Render --> Secrets
+  API & Worker & Render --> Obs
+```
+
+Render jobs are untrusted-code workloads because workshop builds execute repository-defined package
+scripts. They run without long-lived credentials, with read-only source, bounded CPU/memory/time,
+restricted egress, and a disposable filesystem.
+
+## Quality attributes
+
+| Attribute | Architectural response |
+| --- | --- |
+| Correctness | Immutable revisions, semantic diff, state-machine invariants, content hashes |
+| Usability | Role-specific inboxes, deep links to TMS units, rendered side-by-side previews |
+| Portability | Canonical model, XLIFF interchange, provider-neutral adapter contract |
+| Scalability | Queue-backed workers, content-addressed artifacts, incremental extraction/rendering |
+| Testability | Pure domain modules, fakes, conformance kit, hermetic renderer protocol |
+| Recoverability | Idempotent events, replayable jobs, audit log, database PITR, versioned artifacts |
+| Security | Least-privilege apps, signed webhooks, sandboxed renders, no tokens in artifacts |
+| Operability | Correlation IDs, per-revision dashboards, dead-letter replay, explicit SLOs |

--- a/docs/decisions/0014-tms-architecture/testing-strategy.md
+++ b/docs/decisions/0014-tms-architecture/testing-strategy.md
@@ -1,0 +1,273 @@
+# Testing strategy
+
+“Extremely well tested” is a repository policy, not an aspiration. Every user story is executable,
+runs at multiple layers, and is exercised against every production TMS adapter through one
+conformance contract.
+
+## Story-to-test rule
+
+Every feature under `features/` must have:
+
+1. at least one domain-level acceptance test using deterministic fakes;
+2. adapter-conformance scenarios for every supported TMS;
+3. at least one end-to-end happy or failure journey through the public API/CLI;
+4. relevant property, structural, visual, security, or recovery tests; and
+5. traceability from story → scenarios → test runs → release evidence.
+
+No story is “covered” solely because a line-coverage tool touched its implementation.
+
+```mermaid
+flowchart LR
+  Story["User story + examples"]
+  Domain["Domain acceptance"]
+  Contract["Adapter conformance"]
+  E2E["End-to-end journey"]
+  Specialist["Property / visual / chaos / security"]
+  Evidence["Traceability report"]
+
+  Story --> Domain & Contract & E2E & Specialist
+  Domain & Contract & E2E & Specialist --> Evidence
+```
+
+## Executable-story example
+
+```gherkin
+Feature: English changes invalidate only affected locale approvals
+
+  Rule: A semantic source edit requires human revalidation
+
+    Scenario: Reviewed body text changes but the slide ID remains stable
+      Given slide "S00.statement-why" body "promise" is reviewed in German
+      And its rendered German slide is visually approved
+      When the English body changes semantically
+      Then the German body is "needs-editing"
+      And the German visual approval is invalidated
+      And unrelated units remain reviewed
+      And the locale cannot be released
+```
+
+The same scenario is bound to:
+
+- an in-memory backend for fast domain acceptance;
+- the Weblate adapter conformance environment;
+- the Crowdin adapter conformance environment; and
+- an end-to-end system test using the deterministic TMS simulator.
+
+Live provider sandboxes run on a schedule and before adapter releases, not on every contributor pull
+request. This preserves deterministic CI while still detecting real API drift.
+
+## Test architecture
+
+```mermaid
+flowchart TB
+  subgraph Fast["Per change · deterministic"]
+    Unit["Unit tests"]
+    Property["Property/model tests"]
+    Parser["Parser golden + round-trip tests"]
+    Domain["Story/domain acceptance"]
+    ContractFake["Adapter contract against simulator"]
+    Mutation["Targeted mutation tests"]
+  end
+
+  subgraph Integration["Per pull request · hermetic"]
+    DB["Database/queue/object-store integration"]
+    API["API compatibility"]
+    E2E["Browser + CLI journeys"]
+    Render["Representative Slidev builds"]
+    Visual["Structural + visual regression"]
+    Security["SAST, dependencies, image and secret scans"]
+  end
+
+  subgraph External["Scheduled / release candidate"]
+    ProviderA["Live TMS A conformance"]
+    ProviderB["Live TMS B conformance"]
+    Chaos["Fault injection and recovery"]
+    Load["Capacity and soak"]
+    Restore["Backup restore drill"]
+    FullCorpus["Full two-workshop corpus render"]
+  end
+
+  Fast --> Integration --> External
+```
+
+## Required suites
+
+### Domain and state-machine tests
+
+- Model-based tests generate valid and invalid event sequences.
+- Invariants assert that release is impossible with stale, missing, structurally invalid, or
+  visually unapproved required units.
+- Approval invalidation is tested for every input hash.
+- Commands are tested for idempotency and optimistic-concurrency conflicts.
+- Clock, ID generation, storage, queue, and providers are injected dependencies.
+
+### Parser and composer tests
+
+The test corpus contains real workshop sections and minimized adversarial fixtures:
+
+- multi-frontmatter Slidev documents;
+- speaker notes in HTML comments;
+- Vue components with props, slots, directives, and expressions;
+- nested Markdown and raw HTML;
+- magic-move blocks and nested fences;
+- tables, links, inline code, emoji, combining characters, RTL, and CJK;
+- malformed syntax with precise diagnostics;
+- labs with executable and transcript fences; and
+- quizzes with reordered options and stable answer IDs.
+
+Properties:
+
+```text
+compose(source, extract(source, source_language)) == semantic_normalize(source)
+protected_skeleton(compose(source, target)) == protected_skeleton(source)
+extract(serialize(parse(source))) == extract(source)
+compose(source, same_target) is deterministic
+compose(compose(source, target), target) is rejected or stable by contract
+```
+
+Property-based generators mutate whitespace, ordering where legal, Unicode, line endings, source
+locations, and translatable text. Fuzzing targets parser boundaries and never executes generated
+content.
+
+### Golden tests
+
+Golden fixtures record:
+
+- canonical units and identities;
+- XLIFF output;
+- protected skeletons;
+- composed locale Markdown/JSON;
+- diagnostics; and
+- release manifests.
+
+Golden changes require human review and a reason. They are not bulk-regenerated merely to make CI
+green.
+
+### TMS adapter conformance
+
+```mermaid
+sequenceDiagram
+  participant Suite as Conformance suite
+  participant Adapter
+  participant Backend as TMS/simulator
+
+  Suite->>Adapter: ensureWorkspace twice
+  Adapter->>Backend: Create/upsert
+  Suite->>Adapter: publishSource twice with same key
+  Adapter->>Backend: One semantic revision
+  Suite->>Backend: Translate, review, edit source, reorder webhook delivery
+  Backend-->>Adapter: duplicate/out-of-order events
+  Suite->>Adapter: importReviewedTargets from cursor
+  Adapter-->>Suite: one normalized ordered change set
+  Suite->>Suite: assert IDs, inline codes, states, links, cursor, idempotency
+```
+
+The suite covers:
+
+- workspace/project creation and discovery;
+- initial and incremental source publication;
+- rename, obsolete, split, and joined units;
+- Unicode and inline-code preservation;
+- review-state normalization;
+- screenshot/context attachment;
+- pagination and resumable cursors;
+- duplicate and out-of-order webhooks;
+- rate limits, timeouts, partial responses, and provider 5xx errors;
+- token expiry and permission loss;
+- export/import portability; and
+- provider cleanup in isolated test namespaces.
+
+An adapter cannot be labelled production-supported until it passes all mandatory capabilities in a
+live disposable project.
+
+### Visual tests
+
+```mermaid
+flowchart LR
+  Render["Render every click state"]
+  DOM["DOM geometry inspection"]
+  Image["Screenshot analysis"]
+  Fonts["Missing-glyph/font checks"]
+  Compare["Source/target structural comparison"]
+  Human["Human visual approval"]
+
+  Render --> DOM & Image & Fonts & Compare
+  DOM & Image & Fonts & Compare --> Human
+```
+
+Automated checks detect clipping, overflow, invisible text, element collisions, unexpected scroll,
+missing glyphs, render exceptions, blank slides, and lost click states. Pixel diffs are advisory
+because translated text legitimately changes geometry. Human approval remains mandatory for release.
+
+### End-to-end journeys
+
+Browser and CLI tests exercise at minimum:
+
+- onboard a workshop;
+- ingest source and explain its localization impact;
+- translate and review through the TMS simulator;
+- inspect a rendered locale side by side;
+- request and approve an override;
+- release and verify a bundle;
+- process a new English revision and observe selective invalidation;
+- rotate a provider credential;
+- replay a dead-lettered event; and
+- migrate a locale between simulated providers.
+
+### Reliability and chaos tests
+
+- Kill a worker after each durable write and before acknowledgement.
+- Deliver every external event zero, one, and many times in arbitrary order.
+- Introduce provider latency, throttling, malformed pages, and cursor invalidation.
+- Corrupt an object and prove digest verification blocks use.
+- Interrupt a release midway and prove no partial release becomes visible.
+- Restore the database and object store to a chosen recovery point.
+- Run a 24-hour sync/render soak using both workshop corpora.
+
+### Security tests
+
+- Webhook signature and replay-window tests.
+- Authorization matrix tests for author, translator, linguistic reviewer, visual reviewer, operator,
+  and release manager.
+- Tenant/workshop isolation tests on every query boundary.
+- Malicious archive, path traversal, symlink, decompression-bomb, and parser-fuzz fixtures.
+- Sandboxed-render escape and forbidden-network assertions.
+- Secret scanning and redaction tests for logs, traces, artifacts, and diagnostics.
+- Dependency, container, infrastructure, and API dynamic scanning.
+
+## Quality gates
+
+| Gate | Pull request | Main | Release candidate |
+| --- | --- | --- | --- |
+| Unit/domain/property | Required | Required | Required |
+| Parser corpus and golden | Required | Required | Required |
+| Adapter contract vs simulator | Required | Required | Required |
+| Database/API integration | Required | Required | Required |
+| Representative render/visual | Required | Required | Required |
+| Full two-workshop corpus | Changed surfaces | Required | Required |
+| Live provider conformance | No | Scheduled | Required |
+| Mutation testing | Changed critical modules | Scheduled full | Threshold required |
+| Chaos/load/restore | No | Scheduled | Latest run must be current |
+| Security and provenance | Required subset | Required | Required full |
+
+Initial coverage policy:
+
+- 100% branch coverage for release policy, state transitions, identity migration, protected-content
+  validation, and authorization decisions;
+- high project-wide coverage with no arbitrary number used as a substitute for meaningful tests;
+- mutation score of at least 90% on the critical modules above; and
+- every production incident adds a minimized regression fixture before closure.
+
+## Test observability
+
+Every scenario emits a trace with story ID, scenario ID, adapter, workshop fixture, source revision,
+and correlation ID. A generated traceability report answers:
+
+```text
+Which stories have no adapter coverage?
+Which production adapters have not passed live conformance recently?
+Which release-policy branches survived mutation?
+Which workshop syntax constructs exist in production but not the corpus?
+Which visual approvals were produced by an obsolete render profile?
+```
+

--- a/docs/decisions/0014-tms-architecture/tms-evaluation.md
+++ b/docs/decisions/0014-tms-architecture/tms-evaluation.md
@@ -1,0 +1,134 @@
+# TMS evaluation
+
+The architecture intentionally does not declare a provider winner from feature lists. The first
+production authority is chosen through a scripted bake-off using the real hostile corpus, real
+German and Brazilian Portuguese reviewers, and the same conformance stories.
+
+## Candidate posture
+
+The first two adapters target:
+
+- **Weblate:** self-hostable/open-source option with review workflow, translation memory, glossary,
+  context, screenshot, and API capabilities. Its current documentation labels direct Markdown and
+  XLIFF 2 support as under development, so the adapter must prove its exact native/API or file
+  profile rather than relying on format claims.
+- **Crowdin:** managed-service candidate with translation workflow, memory, glossary, webhooks, and
+  APIs. The adapter must pass the same live contract and export-portability tests; managed operation
+  is not evidence of semantic correctness.
+
+This is not a requirement to dual-write production translations. One provider is authoritative for
+each workshop/locale; the second is independently tested, available for a portfolio split or future
+migration, and may run a consented shadow corpus.
+
+## Evaluation flow
+
+```mermaid
+flowchart LR
+  Corpus["Same hostile corpus"]
+  Setup["Scripted clean project setup"]
+  Tasks["Same translator/reviewer tasks"]
+  Contract["Same automated conformance"]
+  Operate["Same failure and export drills"]
+  Score["Evidence-backed scorecard"]
+  Decide["ADR selects initial authority"]
+
+  Corpus --> Setup --> Tasks --> Score
+  Corpus --> Contract --> Score
+  Corpus --> Operate --> Score
+  Score --> Decide
+```
+
+## Weighted scorecard
+
+| Dimension | Weight | Evidence, not sales claims |
+| --- | ---: | --- |
+| Translator and reviewer usability | 25 | Task success, time, errors, SUS-style feedback, accessibility |
+| Identity and source-change correctness | 15 | Live conformance for edit/move/obsolete/split/retry scenarios |
+| Workflow and permissions | 10 | Dedicated review, locale roles, audit history, API state mapping |
+| Context quality | 10 | Notes, screenshots, neighboring strings, deep links, protected tokens |
+| API/webhook reliability | 10 | Pagination, cursor/reconciliation, rate limits, signatures, idempotency |
+| Portability and exit | 10 | Complete exports, reproducible import, identity/state loss report |
+| Cross-workshop memory and glossary | 10 | Shared suggestions without project-state leakage |
+| Operations/security/compliance | 5 | Hosting model, backup, SSO, token scopes, incident posture |
+| Sustainable cost and community fit | 5 | Transparent three-year scenario for contributors/locales/workshops |
+
+A provider must also pass all non-negotiable gates; weighted strength cannot compensate for failed
+protected-content integrity, missing review authority, inability to export accepted translations, or
+unreliable identity.
+
+## Moderated usability script
+
+Each participant performs the same tasks without repository access:
+
+1. find a newly changed German unit from an assignment;
+2. understand where it appears using notes and screenshot context;
+3. translate prose containing protected inline Kubernetes terms;
+4. use glossary and cross-workshop translation-memory suggestions;
+5. submit the unit for review;
+6. review another translator's unit and request a correction;
+7. follow a rendered-overflow deep link back to the exact unit;
+8. request a structural override; and
+9. determine why a seemingly complete locale cannot release.
+
+```mermaid
+journey
+  title Provider usability trial
+  section Orientation
+    Find assigned work: 5: Translator, Reviewer
+    Understand slide context: 5: Translator, Reviewer
+  section Translation
+    Preserve protected tokens: 5: Translator
+    Reuse glossary and memory: 5: Translator
+    Submit and review: 5: Translator, Reviewer
+  section Render feedback
+    Navigate from overflow to unit: 5: Translator, Reviewer
+    Request structural override: 5: Reviewer
+```
+
+Capture task success, assistance needed, wrong turns, elapsed time, token corruption attempts, review
+state mistakes, and qualitative confidence. Five skilled participants per role/locale is a useful
+initial qualitative sample; it is not treated as statistical proof.
+
+## Technical trial corpus
+
+The trial must include:
+
+- a Slidev section with multi-frontmatter, Vue components, slots, speaker notes, magic-move, nested
+  fences, and click states;
+- a contracted lab with prose, tables, inline code, multiple executable fences, and solution links;
+- structured quiz JSON with stable question/option IDs and immutable answer identity;
+- duplicate English prose used in different contexts;
+- source edit, file move, slide insertion, unit split/join, obsolete unit, and terminology change;
+- German overflow requiring one real slide split; and
+- Portuguese content imported from the community contribution as migration evidence.
+
+## Provider decision record
+
+The later selection ADR includes:
+
+- version/date and hosting tier tested;
+- configuration-as-code or reproducible setup procedure;
+- raw conformance and usability evidence;
+- capability gaps and hub-side emulations;
+- export/migration results;
+- three-year operating/cost assumptions;
+- selected authority and fallback adapter;
+- triggers for reevaluation; and
+- confirmation that no provider-specific model leaked into the domain.
+
+## Reevaluation triggers
+
+- mandatory live conformance fails for two consecutive supported provider releases;
+- export loses accepted target identity or review evidence;
+- material API, pricing, hosting, licensing, or security change;
+- translators' task success drops below the accepted baseline;
+- a third workshop requires a missing mandatory capability; or
+- provider-specific emulation becomes a significant part of the hub.
+
+## References
+
+- [Weblate translation workflows](https://docs.weblate.org/en/latest/workflows.html)
+- [Weblate translator context and screenshots](https://docs.weblate.org/en/latest/admin/translating.html)
+- [Weblate XLIFF 2 support](https://docs.weblate.org/en/latest/formats/xliff2.html)
+- [Crowdin documentation](https://support.crowdin.com/)
+

--- a/docs/decisions/0014-tms-architecture/usability-and-journeys.md
+++ b/docs/decisions/0014-tms-architecture/usability-and-journeys.md
@@ -1,0 +1,207 @@
+# Usability and journeys
+
+The hub succeeds only if normal work is easier than editing translated Markdown by hand. Each role
+gets one obvious inbox, actionable status, and a reversible workflow.
+
+## Information architecture
+
+```mermaid
+flowchart TB
+  Home["Portfolio dashboard"]
+  Workshop["Workshop"]
+  Revision["Source revision"]
+  Locale["Locale"]
+  Unit["Translation unit"]
+  Preview["Rendered preview"]
+  Release["Locale release"]
+  Providers["TMS connections"]
+  Audit["Audit and operations"]
+
+  Home --> Workshop
+  Workshop --> Revision & Locale & Release
+  Revision --> Unit & Preview
+  Locale --> Unit & Preview
+  Unit --> Providers
+  Release --> Preview
+  Home --> Providers & Audit
+```
+
+## Portfolio dashboard
+
+```text
+┌─ Localization Hub ──────────────────────────────────────────────────────────┐
+│ Workshops   Needs attention   Ready to release   Provider health           │
+│     2             17                 1             A ✓  B ✓                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Kubernetes Practitioner  source 8f31c2                                     │
+│   de      96% linguistic  92% visual   3 stale   2 overflow   [Open]       │
+│   pt-BR  100% linguistic 100% visual   ready                 [Release]     │
+│ Infrastructure Workshop source a42e90                                     │
+│   de      81% linguistic  79% visual  24 stale               [Open]       │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Percent complete is never the only signal. The dashboard distinguishes untranslated, needs-editing,
+linguistically reviewed, structurally failed, visually failed, visually approved, and released.
+
+## Author journey: change English safely
+
+```mermaid
+sequenceDiagram
+  actor Author
+  participant Git as Workshop repository
+  participant Hub
+  participant TMS
+  participant CI as Preview renderer
+
+  Author->>Git: Open source pull request
+  Git->>Hub: Send immutable source revision
+  Hub->>Hub: Extract and semantic-diff units
+  Hub-->>Git: Check: 12 changed, 3 new, 1 override stale
+  Hub->>TMS: Publish candidate source revision
+  Hub->>CI: Render English structural baseline
+  CI-->>Hub: Baseline evidence
+  Hub-->>Author: Deep links and localization impact
+  Author->>Git: Merge when source checks pass
+  Hub->>TMS: Promote merged revision
+```
+
+The author never edits keys or catalogs. A pull-request check explains localization impact before
+merge without blocking English authoring on translation completion.
+
+## Translator journey: work in a familiar editor
+
+```mermaid
+journey
+  title Translate a changed slide
+  section Find work
+    Open TMS assignment from locale inbox: 5: Translator
+    See English, screenshot, glossary, and notes: 5: Translator
+  section Translate
+    Edit prose without touching protected code: 5: Translator
+    Preview approximate length warning: 4: Translator
+    Submit for linguistic review: 5: Translator
+  section Correct
+    Follow deep link from rendered overflow issue: 4: Translator
+    Revise or request a structural override: 5: Translator
+```
+
+Each TMS unit includes:
+
+- the English source and prior accepted translation;
+- workshop, section, slide, role, and layout context;
+- source and target screenshots when available;
+- protected terms and non-translatable inline tokens;
+- a deep link back to the hub preview;
+- a character-expansion hint, clearly labelled as a hint rather than a layout guarantee.
+
+## Linguistic reviewer journey
+
+```mermaid
+stateDiagram-v2
+  [*] --> Untranslated
+  Untranslated --> Draft: translator saves
+  Draft --> NeedsEditing: translator submits
+  NeedsEditing --> LinguisticallyReviewed: reviewer accepts
+  NeedsEditing --> Draft: reviewer requests changes
+  LinguisticallyReviewed --> NeedsEditing: source semantic change
+  LinguisticallyReviewed --> VisualReview: composition succeeds
+  VisualReview --> NeedsEditing: language correction required
+```
+
+The reviewer works in the TMS, where translation memory and glossary context already exist. The hub
+imports provider state but maps it to its own smaller, provider-independent state machine.
+
+## Visual reviewer journey
+
+```text
+┌─ Visual review: de · S07 · Service types ───────────────────────────────────┐
+│ Source revision 8f31c2   Linguistic review ✓   Structural checks ✓         │
+├───────────────────────────────┬─────────────────────────────────────────────┤
+│ English                       │ German                                      │
+│ [rendered slide + click 0]    │ [rendered slide + click 0]                 │
+│                               │                                             │
+│ [click 1] [click 2] [click 3] │ [click 1] [click 2] [click 3]              │
+├───────────────────────────────┴─────────────────────────────────────────────┤
+│ Issues: text clipped in card 3 · line wrap changed card height             │
+│ [Request wording change] [Create override request] [Approve visual]        │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Visual approval is bound to `(source revision, locale, composed-content hash, render-profile hash)`.
+Any change to those inputs invalidates approval automatically.
+
+## Override journey
+
+```mermaid
+sequenceDiagram
+  actor Reviewer
+  participant Hub
+  participant Git as Localization repository
+  participant CI as Composer/renderer
+  participant TMS
+
+  Reviewer->>Hub: Request slide split with rationale
+  Hub->>Git: Open override pull request from template
+  Reviewer->>Git: Edit localized structural fragment
+  Git->>CI: Validate protected blocks and source anchors
+  CI-->>Hub: Render two-slide target preview
+  Hub->>TMS: Link affected units and pause normal composition
+  Reviewer->>Hub: Approve visual result
+  Hub->>Git: Record approval check
+```
+
+Overrides require a reason: `overflow`, `locale-pedagogy`, `accessibility`, or `other`. The dashboard
+reports override rate by locale and layout. Repeated overrides of one layout create an upstream
+layout-improvement task instead of normalizing permanent forks.
+
+## Facilitator journey
+
+```mermaid
+flowchart LR
+  Choose["Choose workshop + locale"]
+  Status{"Released snapshot exists?"}
+  Download["Download one signed bundle"]
+  Verify["CLI verifies checksum/provenance"]
+  Run["Launch locale deck"]
+  Explain["Read release notes and known fallbacks"]
+
+  Choose --> Status
+  Status -->|Yes| Download --> Verify --> Run
+  Status -->|No| Explain
+```
+
+A facilitator never assembles catalogs or decides whether fuzzy strings are safe. A locale is either
+released for a particular English revision or visibly unavailable. Preview builds may contain
+watermarked English fallback; released builds may not.
+
+## Operator journey
+
+```mermaid
+flowchart TB
+  Alert["Alert: provider webhook lag"]
+  Timeline["Open correlated event timeline"]
+  Cause{"Failure class"}
+  Retry["Replay idempotent job"]
+  Quarantine["Quarantine malformed payload"]
+  Disable["Disable unhealthy adapter"]
+  Shadow["Continue with second adapter / shadow comparison"]
+
+  Alert --> Timeline --> Cause
+  Cause -->|Transient| Retry
+  Cause -->|Bad payload| Quarantine
+  Cause -->|Provider incident| Disable --> Shadow
+```
+
+## Usability acceptance measures
+
+| Measure | Initial target |
+| --- | --- |
+| Author actions to publish changed source units | Zero beyond normal pull request workflow |
+| Translator navigation from task to source slide preview | One click |
+| Reviewer navigation from visual defect to TMS unit | One click |
+| Facilitator actions from released locale to running deck | One command or one download |
+| Unexplained status labels | Zero; every state has cause and next action |
+| Manual reconciliation after duplicate webhook | Zero |
+| Time to reproduce a failed render locally | Under ten minutes from copied command |
+

--- a/docs/decisions/0014-tms-architecture/user-stories-and-traceability.md
+++ b/docs/decisions/0014-tms-architecture/user-stories-and-traceability.md
@@ -1,0 +1,115 @@
+# User stories and traceability
+
+These stories define the product contract. They are intentionally phrased independently of any TMS
+screen or provider API. Scenario files in the future repository use the IDs below.
+
+## Story map
+
+```mermaid
+flowchart LR
+  Author["Author<br/>understand change impact"]
+  Translator["Translator<br/>produce safe contextual targets"]
+  Linguist["Linguistic reviewer<br/>accept language"]
+  Visual["Visual reviewer<br/>accept rendered teaching material"]
+  Facilitator["Facilitator<br/>run a trustworthy locale release"]
+  Operator["Operator<br/>keep integrations recoverable"]
+
+  Author --> Translator --> Linguist --> Visual --> Facilitator
+  Operator -. supports .-> Author & Translator & Linguist & Visual & Facilitator
+```
+
+## Author stories
+
+| ID | Story | Key acceptance examples |
+| --- | --- | --- |
+| AUT-01 | As an author, I edit readable English rather than translation keys. | Extraction requires no prose rewrite; diagnostics point to source locations. |
+| AUT-02 | As an author, I see localization impact before merging. | New, changed, obsolete, override-stale, and visually invalidated counts are separated. |
+| AUT-03 | As an author, I can move a stable slide without losing translations. | Explicit IDs preserve target history across path and ordinal changes. |
+| AUT-04 | As an author, I receive precise errors for unsafe source syntax. | Missing/duplicate IDs and ambiguous translatable boundaries block intake with remediation. |
+
+## Translator stories
+
+| ID | Story | Key acceptance examples |
+| --- | --- | --- |
+| TRN-01 | As a translator, I work in the selected TMS editor. | Source, target, notes, glossary, screenshot, and neighboring context are available. |
+| TRN-02 | As a translator, I cannot accidentally alter executable material. | Protected inline codes and fences are read-only; hostile target imports are rejected. |
+| TRN-03 | As a translator, I reuse terminology across both workshops. | Shared translation memory/glossary suggestions appear without sharing workflow state. |
+| TRN-04 | As a translator, I see exactly what changed in English. | Previous source and target remain visible; changed units become needs-editing. |
+| TRN-05 | As a translator, I request structural help when wording cannot fit. | One action links the unit, slide, screenshot, and proposed override reason. |
+
+## Review stories
+
+| ID | Story | Key acceptance examples |
+| --- | --- | --- |
+| LRV-01 | As a linguistic reviewer, I accept or return translations in the TMS. | Only authorized provider states normalize to reviewed; duplicate events apply once. |
+| LRV-02 | As a linguistic reviewer, source changes invalidate affected approval. | Related unit becomes needs-editing; unrelated units retain approval. |
+| VRV-01 | As a visual reviewer, I compare English and locale renders at every click. | Side-by-side render, issue coordinates, and deep links are available. |
+| VRV-02 | As a visual reviewer, I approve exact render inputs. | Any source, target, override, font/toolchain, or render-profile change invalidates approval. |
+| VRV-03 | As a visual reviewer, I split a crowded slide without forking the deck. | One stable source slide maps to multiple locale slides with protected blocks preserved. |
+
+## Facilitator stories
+
+| ID | Story | Key acceptance examples |
+| --- | --- | --- |
+| FAC-01 | As a facilitator, I download one complete locale bundle. | Deck, labs, quiz, PDF, manifest, and checksums share one source revision. |
+| FAC-02 | As a facilitator, I cannot mistake a preview for a release. | Preview fallback is watermarked; released bundles contain zero fallback units. |
+| FAC-03 | As a facilitator, I verify and run a release without TMS knowledge. | One command verifies provenance and launches the requested locale/day. |
+| FAC-04 | As a facilitator, I understand replacement releases. | Withdrawn release points to its immutable replacement and reason. |
+
+## Operator and portability stories
+
+| ID | Story | Key acceptance examples |
+| --- | --- | --- |
+| OPS-01 | As an operator, I replay transient failures safely. | Worker death and repeated command cause one semantic side effect. |
+| OPS-02 | As an operator, I reconcile lost or reordered provider events. | Cursor pull reaches authoritative state regardless of webhook delivery order. |
+| OPS-03 | As an operator, I diagnose one revision end to end. | Correlated source, provider, composition, render, review, and release timeline exists. |
+| OPS-04 | As an operator, I restore service and reproduce a release. | Point-in-time restore plus object versions reproduce sampled artifact digests. |
+| SEC-01 | As an operator, I execute workshop builds without trusting them. | Sandbox denies network/privilege escape and exposes no long-lived credentials. |
+| PRT-01 | As a maintainer, I can change TMS without losing accepted work. | Portable export/import preserves IDs, targets, provenance, and representable states. |
+| PRT-02 | As a maintainer, I know when an adapter is not equivalent. | Capability negotiation blocks unsupported policy; shadow report explains differences. |
+
+## Required multi-TMS matrix
+
+Every row marked `C` is a mandatory adapter-conformance scenario. `U` is demonstrated in the TMS
+usability trial because it depends on human interaction. `H` belongs to hub behavior and uses each
+adapter as an input, but is not implemented by the TMS itself.
+
+| Story | Simulator | Weblate | Crowdin | Domain/API | End to end | Specialist layer |
+| --- | --- | --- | --- | --- | --- | --- |
+| AUT-01..04 | H | H | H | Required | Required | Parser property/golden |
+| TRN-01 | U | U | U | Contract metadata | Required | Moderated usability |
+| TRN-02 | C | C | C | Required | Required | Security/fuzz |
+| TRN-03 | C | C | C | Mapping | Required | Two-workshop corpus |
+| TRN-04 | C | C | C | Required | Required | State-model test |
+| TRN-05 | H | U | U | Required | Required | Usability |
+| LRV-01..02 | C | C | C | Required | Required | Event permutation |
+| VRV-01..03 | H | H | H | Required | Required | Visual/property |
+| FAC-01..04 | H | H | H | Required | Required | Provenance/reproduction |
+| OPS-01..04 | C | C | C | Required | Required | Chaos/restore/soak |
+| SEC-01 | H | H | H | Authorization | Required | Sandbox/security |
+| PRT-01 | C | C | C | Required | Required | Migration rehearsal |
+| PRT-02 | C | C | C | Required | Required | Shadow comparison |
+
+The two named adapters are candidates, not accepted dependencies. If either fails a mandatory story,
+it is not called production-supported. A replacement adapter must satisfy the same matrix.
+
+## Traceability artifact
+
+```mermaid
+flowchart LR
+  Feature["features/TRN-04.feature"]
+  Scenario["Scenario IDs"]
+  Domain["Domain results"]
+  Sim["Simulator conformance"]
+  LiveA["Live adapter A"]
+  LiveB["Live adapter B"]
+  E2E["E2E result"]
+  Release["Release evidence"]
+
+  Feature --> Scenario
+  Scenario --> Domain & Sim & LiveA & LiveB & E2E
+  Domain & Sim & LiveA & LiveB & E2E --> Release
+```
+
+CI fails when a story lacks its required bindings, even if all existing test files pass.
+

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,7 +32,14 @@ shaped the way it is — not just *what* it looks like.
 | [0011](0011-live-quiz-spike.md) | Defer live-quiz adoption until a complete FOSS runtime passes | proposed |
 | [0012](0012-sibling-lab-solutions.md) | Single-file labs with sibling solution companions | accepted |
 | [0013](0013-opentelemetry-scope.md) | Scope OpenTelemetry as a concept coda on S23, not a new section | accepted |
+| [0014](0014-i18n-without-forking.md) | Internationalization without forking the section library (concept catalog) | proposed |
 | [0015](0015-static-self-check-quiz-player.md) | Ship self-check quizzes as a static Pages player, not a hosted service | accepted |
+
+Option sketches for 0014 (not separate ADRs):
+[`0014-i18n-options/`](0014-i18n-options/).
+
+Proposed standalone implementation architecture for 0014:
+[`0014-tms-architecture/`](0014-tms-architecture/).
 
 ## Template
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,6 +36,17 @@ summarizes; it does not lead over private trackers.
 
 ## Direction
 
+### Internationalization — exploring
+
+How to ship additional languages (**slides, labs, and quiz**) without forking the section library
+or freezing English authoring is **under consideration only**. A proposed concept catalog lives in
+[ADR 0014](./decisions/0014-i18n-without-forking.md): eight elevator pitches, three full sketches,
+five short-form, plus a detailed
+[standalone Localization Hub architecture pack](./decisions/0014-tms-architecture/README.md).
+Emerging study direction: a **TMS-backed hub + generated locale artifacts + governed slide
+overrides**, with story-derived conformance tests across multiple TMS adapters. **No architecture is
+accepted yet**; hand-maintained parallel locale trees (community PR #55) are not the architecture.
+
 ### Live quizzes — planned (host only; the learner self-check is on `main`)
 
 Per-section retrieval questions ship as a portable bank in


### PR DESCRIPTION
## What

- **ADR 0014**: catalogues eight i18n shapes (3 full sketches under `0014-i18n-options/`), records the operator's six goals, and — as of 2026-08-15 — the **critical review and optimized cut**: proceed as a stateless, git-native CLI in the standalone `workshop-i18n` repository; the architecture pack's service runtime and dual-live-adapter requirement are explicitly not adopted.
- **`0014-tms-architecture/` pack**: full domain analysis (system/integration/domain/testing/ops docs + 12 proposed ADRs), preserved with a *partially superseded* banner pointing at `workshop-i18n`.
- `docs/decisions/README.md` + `docs/roadmap.md`: i18n listed as **exploring** → pointer here.

## Why

PR #55 (pt-BR parallel tree) proved demand and the wrong shape (re-creates the ADR 0003 drift problem). This records the shapes considered and the direction chosen without freezing English authoring. The four acceptance spikes continue as Spec Kit features 001–004 in `workshop-i18n`; PR #55 is planned as seed corpus there (spec 004), honoring the contribution.

Docs only — no product code, no winner declared beyond the recorded direction.