### PR TITLE
:lock: fix(deps): clear the nanoid, fast-uri, and browserslist advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,10 +9,12 @@ overrides:
   js-yaml@>=5.0.0 <6.0.0: 5.2.3
   js-yaml@>=4.0.0 <5.0.0: 4.3.1
   js-yaml@>=3.0.0 <4.0.0: 3.15.1
-  nanoid@>=3.0.0 <4.0.0: 3.3.17
+  nanoid@>=3.0.0 <4.0.0: 3.3.18
   dompurify: 3.4.13
   '@hono/node-server': 2.1.0
   mermaid: 11.16.1
+  fast-uri: 3.1.6
+  browserslist: 4.28.7
 
 importers:
 
@@ -1353,8 +1355,8 @@ packages:
     resolution: {integrity: sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==}
     engines: {node: '>=20.19.0'}
 
-  baseline-browser-mapping@2.10.41:
-    resolution: {integrity: sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==}
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1372,8 +1374,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.4:
-    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1393,8 +1395,8 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  caniuse-lite@1.0.30001800:
-    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1769,8 +1771,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.384:
-    resolution: {integrity: sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==}
+  electron-to-chromium@1.5.422:
+    resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1839,8 +1841,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2477,8 +2479,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2488,8 +2490,8 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  node-releases@2.0.50:
-    resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
     engines: {node: '>=18'}
 
   normalize-path@3.0.0:
@@ -3071,7 +3073,7 @@ packages:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.7
 
   uqr@0.1.3:
     resolution: {integrity: sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==}
@@ -3327,7 +3329,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.4
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -4912,7 +4914,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4948,7 +4950,7 @@ snapshots:
       '@babel/types': 7.29.7
       ast-kit: 2.2.0
 
-  baseline-browser-mapping@2.10.41: {}
+  baseline-browser-mapping@2.11.21: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4960,13 +4962,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.4:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.10.41
-      caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.384
-      node-releases: 2.0.50
-      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.422
+      node-releases: 2.0.54
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   bundle-name@4.1.0:
     dependencies:
@@ -4990,7 +4992,7 @@ snapshots:
 
   cac@7.0.0: {}
 
-  caniuse-lite@1.0.30001800: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -5375,7 +5377,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.384: {}
+  electron-to-chromium@1.5.422: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5426,7 +5428,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6225,13 +6227,13 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanotar@0.3.0: {}
 
   node-fetch-native@1.6.7: {}
 
-  node-releases@2.0.50: {}
+  node-releases@2.0.54: {}
 
   normalize-path@3.0.0: {}
 
@@ -6399,7 +6401,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6885,9 +6887,9 @@ snapshots:
       scule: 1.3.0
     optional: true
 
-  update-browserslist-db@1.2.3(browserslist@4.28.4):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.4
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,10 +24,12 @@ overrides:
   "js-yaml@>=4.0.0 <5.0.0": 4.3.1
   "js-yaml@>=3.0.0 <4.0.0": 3.15.1
   # GHSA-2v37-7h3g-55p8: nanoid custom generators can loop indefinitely when
-  # size is zero. Patched separately per line (3.x at 3.3.17, 5.x at 5.1.6);
+  # size is zero. Patched separately per line (3.x at 3.3.18, 5.x at 5.1.6);
   # postcss pulls the 3.x line transitively, so pin that range to its first
   # patched version without dragging any consumer across a major boundary.
-  "nanoid@>=3.0.0 <4.0.0": 3.3.17
+  # The advisory range was widened after 3.3.17 shipped an incomplete fix, so
+  # the 3.x floor is now 3.3.18.
+  "nanoid@>=3.0.0 <4.0.0": 3.3.18
   # monaco-editor / mermaid pull older DOMPurify; pin the patched line.
   dompurify: 3.4.13
   # Dependabot/GHSA collapses @hono/node-server to "<2.0.5" even though
@@ -41,9 +43,26 @@ overrides:
   # and sibling-element CSS injection (GHSA-3rrr-jr9j-h3q3). The deck only uses
   # flowchart and stateDiagram-v2, so this is a patch bump on the same line.
   mermaid: 11.16.1
+  # Four advisories against the fast-uri that ajv resolves URI references with,
+  # all first patched in 3.1.6: host confusion via skipped IDN canonicalization
+  # on scheme-relative references (GHSA-5jgf-p345-68v8) and via percent-encoded
+  # scheme normalization (GHSA-jqff-g426-hqxp), and SSRF via malformed IPv6
+  # normalization (GHSA-f65p-4m7j-42xc) and repeated hostname percent-decoding
+  # (GHSA-fph4-wmhf-6fwf). ajv's own range is already ^3.0.1, so this pins the
+  # floor rather than moving a line; only scripts/quiz/validate.mjs uses ajv,
+  # against schemas and data from this repository.
+  fast-uri: 3.1.6
+  # Two advisories against the browserslist @babel/helper-compilation-targets
+  # pulls in for the Vite/Slidev JSX transform, both first patched in 4.28.7:
+  # unbounded query-cache growth leading to OOM (GHSA-c83g-rgw3-j3cx) and an
+  # uncaught crash / prototype write in normalizeStats when parsing an
+  # untrusted browserslist-stats.json (GHSA-73wf-gq98-2v4g). A patch bump on
+  # the same line; the build never reads a custom stats file.
+  browserslist: 4.28.7
 
 # pnpm 11 minimumReleaseAge gate: allow this override pin through when fresh on the registry.
 minimumReleaseAgeExclude:
   - '@hono/node-server@2.1.0'
-  - 'nanoid@3.3.17'
+  - 'nanoid@3.3.18'
+  - 'fast-uri@3.1.6'
 

--- a/scripts/dependency-audit.test.mjs
+++ b/scripts/dependency-audit.test.mjs
@@ -360,7 +360,15 @@ test('nanoid override is bounded to the intended 3.x major at its patched floor'
   const root = path.resolve(import.meta.dirname, '..')
   const workspace = await readFile(path.join(root, 'pnpm-workspace.yaml'), 'utf8')
 
-  assert.match(workspace, /"nanoid@>=3\.0\.0 <4\.0\.0": 3\.3\.17/)
+  assert.match(workspace, /"nanoid@>=3\.0\.0 <4\.0\.0": 3\.3\.18/)
   assert.doesNotMatch(workspace, /"nanoid@>=3\.0\.0":/)
   assert.doesNotMatch(workspace, /(^|\s)nanoid:/m)
+})
+
+test('fast-uri and browserslist overrides sit at their advisory patched floors', async () => {
+  const root = path.resolve(import.meta.dirname, '..')
+  const workspace = await readFile(path.join(root, 'pnpm-workspace.yaml'), 'utf8')
+
+  assert.match(workspace, /(^|\s)fast-uri: 3\.1\.6/m)
+  assert.match(workspace, /(^|\s)browserslist: 4\.28\.7/m)
 })

--- a/supply-chain/dependency-advisories.json
+++ b/supply-chain/dependency-advisories.json
@@ -1,5 +1,5 @@
 {
-  "captured": "2026-08-09",
+  "captured": "2026-09-05",
   "source": "GitHub Global Security Advisory API",
   "advisories": [
     {
@@ -43,8 +43,8 @@
       "package": "nanoid",
       "ecosystem": "npm",
       "severity": "high",
-      "vulnerableVersionRange": "< 3.3.17",
-      "firstPatchedVersion": "3.3.17",
+      "vulnerableVersionRange": "< 3.3.18",
+      "firstPatchedVersion": "3.3.18",
       "source": "https://github.com/advisories/GHSA-2v37-7h3g-55p8"
     },
     {
@@ -55,6 +55,132 @@
       "vulnerableVersionRange": ">= 4.0.0, < 5.1.6",
       "firstPatchedVersion": "5.1.6",
       "source": "https://github.com/advisories/GHSA-2v37-7h3g-55p8"
+    },
+    {
+      "id": "GHSA-5jgf-p345-68v8",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 2.4.2, < 2.4.5",
+      "firstPatchedVersion": "2.4.5",
+      "source": "https://github.com/advisories/GHSA-5jgf-p345-68v8"
+    },
+    {
+      "id": "GHSA-5jgf-p345-68v8",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 3.1.3, < 3.1.6",
+      "firstPatchedVersion": "3.1.6",
+      "source": "https://github.com/advisories/GHSA-5jgf-p345-68v8"
+    },
+    {
+      "id": "GHSA-5jgf-p345-68v8",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.1, < 4.1.3",
+      "firstPatchedVersion": "4.1.3",
+      "source": "https://github.com/advisories/GHSA-5jgf-p345-68v8"
+    },
+    {
+      "id": "GHSA-f65p-4m7j-42xc",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 2.3.1, < 2.4.5",
+      "firstPatchedVersion": "2.4.5",
+      "source": "https://github.com/advisories/GHSA-f65p-4m7j-42xc"
+    },
+    {
+      "id": "GHSA-f65p-4m7j-42xc",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 3.0.0, < 3.1.6",
+      "firstPatchedVersion": "3.1.6",
+      "source": "https://github.com/advisories/GHSA-f65p-4m7j-42xc"
+    },
+    {
+      "id": "GHSA-f65p-4m7j-42xc",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.0, < 4.1.3",
+      "firstPatchedVersion": "4.1.3",
+      "source": "https://github.com/advisories/GHSA-f65p-4m7j-42xc"
+    },
+    {
+      "id": "GHSA-fph4-wmhf-6fwf",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 2.4.1, < 2.4.5",
+      "firstPatchedVersion": "2.4.5",
+      "source": "https://github.com/advisories/GHSA-fph4-wmhf-6fwf"
+    },
+    {
+      "id": "GHSA-fph4-wmhf-6fwf",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 3.1.2, < 3.1.6",
+      "firstPatchedVersion": "3.1.6",
+      "source": "https://github.com/advisories/GHSA-fph4-wmhf-6fwf"
+    },
+    {
+      "id": "GHSA-fph4-wmhf-6fwf",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.0, < 4.1.3",
+      "firstPatchedVersion": "4.1.3",
+      "source": "https://github.com/advisories/GHSA-fph4-wmhf-6fwf"
+    },
+    {
+      "id": "GHSA-jqff-g426-hqxp",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 2.3.1, < 2.4.5",
+      "firstPatchedVersion": "2.4.5",
+      "source": "https://github.com/advisories/GHSA-jqff-g426-hqxp"
+    },
+    {
+      "id": "GHSA-jqff-g426-hqxp",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 3.0.0, < 3.1.6",
+      "firstPatchedVersion": "3.1.6",
+      "source": "https://github.com/advisories/GHSA-jqff-g426-hqxp"
+    },
+    {
+      "id": "GHSA-jqff-g426-hqxp",
+      "package": "fast-uri",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": ">= 4.0.0, < 4.1.3",
+      "firstPatchedVersion": "4.1.3",
+      "source": "https://github.com/advisories/GHSA-jqff-g426-hqxp"
+    },
+    {
+      "id": "GHSA-73wf-gq98-2v4g",
+      "package": "browserslist",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": "<= 4.28.6",
+      "firstPatchedVersion": "4.28.7",
+      "source": "https://github.com/advisories/GHSA-73wf-gq98-2v4g"
+    },
+    {
+      "id": "GHSA-c83g-rgw3-j3cx",
+      "package": "browserslist",
+      "ecosystem": "npm",
+      "severity": "high",
+      "vulnerableVersionRange": "<= 4.28.6",
+      "firstPatchedVersion": "4.28.7",
+      "source": "https://github.com/advisories/GHSA-c83g-rgw3-j3cx"
     }
   ]
 }


### PR DESCRIPTION
## What this clears

Seven high advisories that hard-fail `scripts/dependency-audit.mjs` and therefore block every merge in the repo. All seven had published fixes on the line already in the graph, so each is a patch bump rather than a major move.

| Package | Advisories | Move |
| --- | --- | --- |
| `nanoid` (3.x) | GHSA-2v37-7h3g-55p8 | 3.3.17 → 3.3.18 |
| `fast-uri` | GHSA-5jgf-p345-68v8, GHSA-jqff-g426-hqxp, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf | pin floor at 3.1.6 |
| `browserslist` | GHSA-c83g-rgw3-j3cx, GHSA-73wf-gq98-2v4g | 4.28.7 |

`nanoid` reopened: 3.3.17 shipped an incomplete fix and the advisory's 3.x range widened to `< 3.3.18`. `fast-uri` is reached only through `ajv` (used by `scripts/quiz/validate.mjs`, against schemas and data from this repository); `browserslist` only through `@babel/helper-compilation-targets` for the Vite/Slidev JSX transform.

**No exception was added.** The two active exceptions remain the pre-existing `image-size` pair (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq, both expiring 2026-10-08); every advisory here is cleared by a real version bump.

## Key finding: the checked-in evidence floor was stale and masking a live vulnerability

`supply-chain/dependency-advisories.json` recorded GHSA-2v37-7h3g-55p8's 3.x range as `< 3.3.17` with `firstPatchedVersion: 3.3.17`. Upstream had since widened that range to `< 3.3.18` because 3.3.17's fix was incomplete. The locked graph sat at exactly `nanoid@3.3.17` — genuinely vulnerable, but *inside* the stale floor, so the gate's locked-evidence half reported "no package version is inside a recorded vulnerable range" and passed while `pnpm audit` failed against live advisory data.

The two halves of the gate disagreeing is the signal worth keeping: locked evidence is only as good as its last capture. `captured` moves 2026-08-09 → 2026-09-05 alongside the corrected range.

## Verification

Gate matrix re-run green on the rebased head (`d468472`):

- `pnpm install --frozen-lockfile`
- `node scripts/dependency-audit.mjs` — exit 0, `critical=0, high=2` (both the excepted `image-size` pair)
- `node --test scripts/supply-chain-policy.test.mjs scripts/dependency-audit.test.mjs` — 62/62
- `pnpm test:deck` — 96/96
- `pnpm decks:check` — generated decks current
- `pnpm build:day1`

This turns the **Supply-chain policy and dependency audit** check, currently red on `main`, back to green.

## Review

Independent review (not the author): **APPROVE**, no P0/P1. Three P3 follow-ups recorded, none blocking:

1. Consider bounding the `fast-uri` override to its major range `">=3.0.0 <4.0.0"` to match the `nanoid`/`js-yaml` treatment.
2. `dependency-advisories.json` is not exhaustive for these packages — no exposure today, since every pin sits above all known floors, but worth noting.
3. The new test asserts the workspace override string rather than the resolved lockfile version; the resolved-version case is covered in aggregate by `evaluateLockedAdvisories`.
