### PR TITLE
:sparkles: feat(quiz): ship the static self-check quiz player at /quiz/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-      # Zero-dependency Node script — no pnpm install needed. Fails on a missing
+          cache: pnpm
+      # link-check.mjs itself is a zero-dependency Node script. Fails on a missing
       # internal target, a broken relative anchor, or an unresolved <pages-url>.
       - run: node scripts/link-check.mjs
+      # pages-site.test.mjs stopped being dependency-free when US-QUIZ-4 added the
+      # end-to-end /quiz/ player test: it builds the published tree and drives it
+      # in headless Chromium, so this job now needs the same install and OS libs
+      # the deck build uses. The alternative -- letting the browser test skip when
+      # Playwright is absent -- is exactly the defect (F4) that test exists to
+      # prevent, so it must never be allowed to no-op.
+      - run: pnpm install --frozen-lockfile
+      - name: Install Chromium system dependencies
+        run: pnpm exec playwright install-deps chromium
       - run: node --test scripts/pages-site.test.mjs
 
   infra:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,7 @@ name: Deploy to GitHub Pages
 #   <pages-url>/deck/3day/       → canonical 3-day cut
 #   <pages-url>/deck/day-{1,2,3}/→ live day entries
 #   <pages-url>/deck/templates/  → design-system gallery
+#   <pages-url>/quiz/            → static self-check quiz player (zero deps)
 # Legacy /3day/ and /templates/ URLs redirect into /deck/…
 #
 # One-time manual prerequisite: Settings → Pages → Source = "GitHub Actions".
@@ -77,7 +78,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
-      - name: Build MkDocs + Slidev Pages tree
+      - name: Build MkDocs + Slidev + quiz-player Pages tree
         # Base path MUST use the exact repo-name case (Kubernetes-Workshop).
         # Hash router is required so slide deep links / refreshes work on
         # project Pages (history mode 404s under the subpath).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ telemetry.
 | **Live decks** | [Day 1](https://platformrelay.github.io/Kubernetes-Workshop/deck/day-1/) · [Day 2](https://platformrelay.github.io/Kubernetes-Workshop/deck/day-2/) · [Day 3](https://platformrelay.github.io/Kubernetes-Workshop/deck/day-3/) · [3-day cut](https://platformrelay.github.io/Kubernetes-Workshop/deck/3day/) · [Superset](https://platformrelay.github.io/Kubernetes-Workshop/deck/) |
 | **PDF handouts** | [GitHub Releases](https://github.com/PlatformRelay/Kubernetes-Workshop/releases) (day + full + 3-day PDFs on each `v*` tag) |
 | **Labs** | [`labs/README.md`](./labs/README.md) · start at [`labs/day-1/00-setup.md`](./labs/day-1/00-setup.md) |
-| **Quizzes** | [`quiz/README.md`](./quiz/README.md) (portable bank; FOSS live host still open) |
+| **Quizzes** | [Self-check quiz](https://platformrelay.github.io/Kubernetes-Workshop/quiz/) in the browser · [`quiz/README.md`](./quiz/README.md) (portable bank; FOSS live host still open) |
 | **Run slides locally** | [`docs/run-slides.md`](./docs/run-slides.md) (Node.js + pnpm) |
 | **Known limitations** | [`docs/beta-limitations.md`](./docs/beta-limitations.md) (S24 stub; add-on smoke backlog) |
 | **Roadmap** | [`docs/roadmap.md`](./docs/roadmap.md) (quizzes, OpenTelemetry — no dates) |
@@ -53,6 +53,9 @@ telemetry.
 - **Facilitator support** — syllabus, pacing notes, and add-on checklists in
   [`docs/facilitator-guide.md`](./docs/facilitator-guide.md).
 - **Offline PDFs** — every release exports day decks plus full/3-day compatibility PDFs.
+- **A self-check quiz** — [answer in the browser](https://platformrelay.github.io/Kubernetes-Workshop/quiz/)
+  and see the explanation, plus why the distractor was tempting. No account, no backend, nothing
+  stored or uploaded. It is a self-check, **not an exam**: the answers ship in the static files.
 
 ## Audience
 
@@ -155,7 +158,7 @@ pnpm pages:build        # MkDocs + hash-routed decks → ./site (needs MkDocs)
 | `slides.md` / `slides-3day.md` | Compatibility superset / three-day cut |
 | `pages/SNN-topic/` | Section sources |
 | `labs/day-*/` | Standalone labs |
-| `quiz/` | Portable question bank |
+| `quiz/` | Portable question bank + the static self-check player |
 | `theme/` | Local Slidev theme |
 | `docs/decisions/` | ADRs |
 
@@ -164,7 +167,7 @@ pnpm pages:build        # MkDocs + hash-routed decks → ./site (needs MkDocs)
 | Workflow | Trigger | Role |
 | --- | --- | --- |
 | `ci.yml` | PR + `main` | Labs lint, deck builds, link-check, Pages contract tests, showcase GIF |
-| `pages.yml` | `main` (+ manual) | MkDocs + Slidev → GitHub Pages |
+| `pages.yml` | `main` (+ manual) | MkDocs + Slidev + quiz player → GitHub Pages |
 | `release.yml` | `v*` tags | PDF + offline zip GitHub Release |
 | `lab-smoke.yml` | schedule / dispatch / PR subset | Disposable kind Day-1 smoke |
 | `codeql.yml` | `main` / schedule | Code scanning |

--- a/docs/decisions/0015-static-self-check-quiz-player.md
+++ b/docs/decisions/0015-static-self-check-quiz-player.md
@@ -1,0 +1,167 @@
+# ADR 0015: Ship self-check quizzes as a static Pages player, not a hosted service
+
+- **Status:** accepted (2026-09-05)
+- **Scope:** how a learner answers a workshop quiz question and gets feedback — the delivery
+  surface, where the question bank lives at runtime, what is persisted, and what the workshop is
+  allowed to claim about the result. It does **not** decide the live-room aggregate question, which
+  stays with [ADR 0011](0011-live-quiz-spike.md) and US-QUIZ-3.
+
+## Context
+
+[ADR 0011](0011-live-quiz-spike.md) evaluated three FOSS live-quiz runtimes and adopted **none of
+them (0 of 3)**: every candidate failed the complete-runtime licence gate. That verdict was correct
+and it is not being reopened here. But it left the workshop with a reviewed question bank —
+`quiz/questions.json`, 54 questions across 27 authored sections, each with an answer, an
+explanation, and a per-distractor rationale — whose **only** learner-facing delivery was a printed
+Markdown handout. A learner working through the deck alone at home could read the questions and
+could read the answer key; there was nothing that let them *commit* to an answer first.
+
+That gap matters more than it looks. Retrieval practice works because the learner commits before
+seeing the answer; a document that shows the question and its answer in the same scroll is a
+reference sheet, not a check. Meanwhile the material the bank already carries — *why this distractor
+was tempting* — is exactly the feedback a self-directed learner cannot get from a handout, because
+they never picked the distractor.
+
+Four forces constrain the answer:
+
+1. **The publishing surface already exists.** `scripts/pages-build.sh` builds an MkDocs landing plus
+   six Slidev decks under `/deck/` and GitHub Pages serves the result. Anything that fits in that
+   tree costs one build step and no infrastructure.
+2. **A host is a standing obligation.** [ADR 0006](0006-workshop-environment-and-iac.md) and
+   [ADR 0007](0007-kubernetes-currency-and-version-pinning.md) put every runtime component behind a
+   pin and a per-delivery review. A quiz backend is a service to run, patch, back up, and eventually
+   turn off — and ADR 0011 already found no FOSS candidate whose licence position was clean.
+3. **The bank must stay the source of truth.** Correct answers, explanations, rationales, learning
+   objectives, and currency references live in the repository and are gated by
+   `scripts/quiz/validate.mjs`. Any delivery that copies them into a vendor database forks the truth.
+4. **A static page cannot keep a secret.** Whatever ships to the browser is readable by whoever
+   receives it. That is a hard property, not an implementation detail, and it decides what the
+   feature is allowed to be.
+
+## Options considered
+
+Criteria and weights. Weights reflect what actually gates this workshop: a learner reaching the
+material unaided, and the maintenance load of anything that has to keep running.
+
+| # | Criterion | Weight |
+| --- | --- | --- |
+| C1 | A solo learner gets commit-then-feedback with no host, account, or install | 5 |
+| C2 | Operational cost — anything that must be run, patched, or paid for | 5 |
+| C3 | Keeps `quiz/questions.json` the single source of truth | 4 |
+| C4 | Privacy — what leaves the learner's browser | 4 |
+| C5 | Authoring + maintenance cost of the delivery itself | 3 |
+| C6 | Supports a facilitator's live room (aggregate answers, show of hands) | 2 |
+| C7 | Reversibility if the decision is wrong | 2 |
+
+Scores are 1–5, where **5 is best for the workshop** (so a cheap option scores high on C2 and C5).
+
+| Option | C1 ×5 | C2 ×5 | C3 ×4 | C4 ×4 | C5 ×3 | C6 ×2 | C7 ×2 | **Total /125** |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **A** — Markdown handout only (status quo) | 1 (5) | 5 (25) | 5 (20) | 5 (20) | 5 (15) | 3 (6) | 5 (10) | **101** |
+| **B** — static player on the existing Pages tree | 5 (25) | 5 (25) | 5 (20) | 5 (20) | 4 (12) | 2 (4) | 5 (10) | **116** |
+| **C** — questions embedded in the Slidev deck | 3 (15) | 4 (20) | 2 (8) | 5 (20) | 2 (6) | 4 (8) | 3 (6) | **83** |
+| **D** — self-hosted live quiz service | 4 (20) | 1 (5) | 2 (8) | 2 (8) | 1 (3) | 5 (10) | 2 (4) | **58** |
+
+### Option A — keep the Markdown handout only
+
+The participant/facilitator export from `scripts/quiz/export.mjs` already works, costs nothing, and
+is the right artifact for a room with no internet. It scores full marks on everything except the one
+thing this decision is about: a learner reading `participant.md` has no way to commit to an answer
+and no way to see the rationale for the distractor that tempted them without also reading the whole
+key. C1 = 1.
+
+### Option B — a zero-dependency static player under `/quiz/`
+
+Plain HTML, CSS, and ES modules published as a sibling of `/deck/` on the artifact
+`scripts/pages-build.sh` already produces. The bank is copied in verbatim at build time, so the
+repository stays the source of truth (C3 = 5). No server, no account, no database, no third-party
+script, so C2 and C4 are free. The cost is a real one — a small UI the workshop now owns and must
+keep working — which is why C5 is 4 rather than 5, and why the player's decision-making logic is
+kept in one pure, directly tested module rather than tangled into DOM handlers.
+
+Its honest weakness is C6: it tells one learner how they did and nobody else. It cannot show a
+facilitator how the room answered, which is the entire point of a live quiz.
+
+### Option C — embed the questions in the Slidev deck
+
+Slides can hold interactive Vue components, so the questions could live inside the deck. This looks
+tempting because the deck is already published, but it fails on C3: the questions would either be
+duplicated into slide sources (two truths, drifting) or injected by a build step that makes the deck
+depend on the bank. [ADR 0003](0003-deck-composition-superset-and-boil-down.md) already keeps deck
+composition mechanical and generated; adding quiz bodies to slide source works against that, and
+US-QUIZ-2 explicitly ruled that quiz bodies do not enter slide sources. It also spends slide minutes
+the three-day schedule does not have.
+
+### Option D — self-host a live quiz service
+
+The right shape for a facilitated room, and the only option that answers C6 properly. It is also the
+option ADR 0011 already tested and rejected: 0 of 3 candidates passed the complete-runtime FOSS
+licence gate. Beyond the licence position it is a service with a database, a TLS endpoint, a backup
+story, and a per-delivery pin — against a workshop whose entire value proposition is that you can
+clone it and go. C2 = 1.
+
+## Decision
+
+**Option B.** Self-check quizzes ship as a zero-dependency static player published at `/quiz/` on
+the existing GitHub Pages artifact. These rules apply:
+
+1. **No runtime dependencies.** The player is vanilla HTML, CSS, and ES modules. It adds **no npm
+   package, no Python package, no CDN script, no webfont, and no third-party origin**. A test asserts
+   the player sources load nothing external.
+2. **The bank stays the source of truth.** `scripts/quiz/build-player.mjs` copies
+   `quiz/questions.json` verbatim into the published tree and derives the section index from
+   `scripts/deck-manifest.mjs`. Questions are never re-authored for the player.
+3. **Session-only, and nothing leaves the browser.** No `localStorage`, no cookie, no telemetry, no
+   analytics, no central collection, no account. A reload clears the score. This is enforced by a
+   test, not by intent.
+4. **Feedback is the point.** Choosing an option locks the question, marks chosen against correct,
+   **always** shows the `explanation`, and on a wrong choice also shows that option's `rationale`.
+   Every rationale is available behind an explicit "show all rationales" opt-in.
+5. **Authored sections only.** The landing page is grouped by day with titles from the deck
+   manifest, and lists only sections that are `authored` **and** actually have questions — so
+   deferred **S24** is not offered. A `#SNN` deep link filters to that section; a link naming a
+   section with no questions falls back to the rendered landing page with an explanation, never to a
+   blank page.
+6. **The Markdown export survives.** `participant.md` and `facilitator.md` remain the offline and
+   show-of-hands fallback for rooms without internet. The player is an addition, not a replacement.
+7. **`quiz-live` is not revived.** ADR 0011's verdict stands; US-QUIZ-3 remains exploring. This ADR
+   does not deliver live-room aggregates and must not be cited as if it did.
+
+### Non-goal: this is not exam security, and must never be described as such
+
+**The player cannot hide an answer, and the workshop will not pretend it can.** Every correct
+answer, explanation, and distractor rationale is in `questions.json` next to the page; a reader can
+open the file, read the network tab, or read the source. This is a property of static publishing,
+not a bug to be fixed later by obfuscation.
+
+The consequences are binding on wording as well as code:
+
+- No proctoring, no score submission, no certificate, no pass mark, no leaderboard, no identity.
+- No hashing, encryption, or server round-trip to "protect" answers. Obfuscation on a static page
+  buys nothing and would misrepresent what the page is.
+- The player itself, `quiz/README.md`, and the front-door docs must say plainly that answers ship in
+  the static files and that a score is feedback for the learner alone.
+- If the workshop ever needs an assessment whose answers are genuinely withheld, that is a different
+  system with a server and a new ADR — it is **not** a hardening pass on this one.
+
+## Consequences
+
+- A solo learner can check their mental model from the published site with no host, account,
+  install, or network beyond loading the page. That is what the story asked for.
+- The workshop now owns a small piece of UI. The cost is contained by keeping every decision
+  (grading, deep-link resolution, session walk) in `quiz/player/logic.mjs`, which `node --test`
+  imports and drives directly, with DOM wiring in a thin `app.mjs`; the published tree is built by
+  `scripts/quiz/build-player.mjs` and then driven in a real browser by `scripts/pages-site.test.mjs`.
+  Neither test settles for asserting that a file exists.
+- Adding a question to `quiz/questions.json` publishes it to the player on the next Pages build. No
+  second place to edit, and `pnpm quiz:validate` still gates it.
+- Deferred **S24** appears nowhere in the player. When that section is authored and gains questions,
+  it appears automatically — no player change.
+- The player answers one learner and cannot answer a room. Facilitators keep the Markdown
+  facilitator copy for show-of-hands, and the live-aggregate question stays open under ADR 0011 /
+  US-QUIZ-3 rather than being quietly declared solved.
+- Publishing the answers is a deliberate, permanent trade. It is written into the page, the quiz
+  README, and this ADR so nobody later mistakes the feature for an assessment tool.
+- **Revert path:** delete `quiz/player/`, `scripts/quiz/build-player.mjs`, the `/quiz/` step in
+  `scripts/pages-build.sh`, and the player tests. The bank, the Markdown export, and the rest of the
+  Pages tree are untouched, because the player only ever reads them.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,6 +32,7 @@ shaped the way it is — not just *what* it looks like.
 | [0011](0011-live-quiz-spike.md) | Defer live-quiz adoption until a complete FOSS runtime passes | proposed |
 | [0012](0012-sibling-lab-solutions.md) | Single-file labs with sibling solution companions | accepted |
 | [0013](0013-opentelemetry-scope.md) | Scope OpenTelemetry as a concept coda on S23, not a new section | accepted |
+| [0015](0015-static-self-check-quiz-player.md) | Ship self-check quizzes as a static Pages player, not a hosted service | accepted |
 
 ## Template
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -14,6 +14,7 @@ navigation and hard refreshes work on project Pages).
 | **Day 2** entry | <https://platformrelay.github.io/Kubernetes-Workshop/deck/day-2/> |
 | **Day 3** entry | <https://platformrelay.github.io/Kubernetes-Workshop/deck/day-3/> |
 | **Template gallery** | <https://platformrelay.github.io/Kubernetes-Workshop/deck/templates/> |
+| **Self-check quiz** | <https://platformrelay.github.io/Kubernetes-Workshop/quiz/> |
 
 Deep-link to a slide with a hash fragment, for example
 `…/deck/day-1/#/5` for slide 5 of Day 1.
@@ -56,4 +57,19 @@ notes body. How tags are cut: [release.md](./release.md).
 | --- | --- |
 | Participant labs | [labs/README.md](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/labs#readme) |
 | Lab 00 (start here) | [labs/day-1/00-setup.md](https://github.com/PlatformRelay/Kubernetes-Workshop/blob/main/labs/day-1/00-setup.md) |
+| Self-check quiz (in the browser) | <https://platformrelay.github.io/Kubernetes-Workshop/quiz/> |
 | Question bank | [quiz/README.md](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz#readme) |
+
+### Self-check quiz
+
+Pick an answer and see straight away whether it holds, with the explanation and — when you miss —
+why that distractor was tempting. Deep-link to one section with a hash fragment, for example
+`…/quiz/#S05`.
+
+It runs entirely in your browser: **no account, no backend, nothing stored, nothing uploaded**, and
+the score is gone on reload. It is a **self-check, not an exam** — the answers ship inside the static
+files, so anyone can read them, and no obfuscation will be added to pretend otherwise
+([ADR 0015](https://github.com/PlatformRelay/Kubernetes-Workshop/blob/main/docs/decisions/0015-static-self-check-quiz-player.md)).
+
+For a room with no internet, or for a show of hands, the printable participant/facilitator Markdown
+export from the same question bank remains the fallback.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ under the [0BSD License](https://github.com/PlatformRelay/Kubernetes-Workshop/bl
 
 [Interactive decks :octicons-arrow-right-24:](downloads.md#interactive-slidev-decks){ .md-button .md-button--primary }
 [PDF downloads :octicons-download-24:](downloads.md#pdf-downloads){ .md-button }
+[Self-check quiz :octicons-checklist-24:](https://platformrelay.github.io/Kubernetes-Workshop/quiz/){ .md-button }
 [Run locally :octicons-terminal-24:](run-slides.md){ .md-button }
 
 ## Why this workshop
@@ -53,7 +54,8 @@ under the [0BSD License](https://github.com/PlatformRelay/Kubernetes-Workshop/bl
 | Run Slidev on your laptop | [Run the slides locally](run-slides.md) |
 | Do the labs | [Labs guide](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/labs#readme) · [Lab 00 setup](https://github.com/PlatformRelay/Kubernetes-Workshop/blob/main/labs/day-1/00-setup.md) |
 | Stand up a local kind cluster | [Local kind setup](setup.md) |
-| Try the question bank | [Quiz README](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz#readme) |
+| Check yourself on a section | [Self-check quiz](https://platformrelay.github.io/Kubernetes-Workshop/quiz/) (in the browser; nothing stored) |
+| Read or reuse the question bank | [Quiz README](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz#readme) |
 | See the full section map | [Syllabus](syllabus.md) |
 | Facilitate a room | [Facilitator guide](facilitator-guide.md) |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,14 +36,22 @@ summarizes; it does not lead over private trackers.
 
 ## Direction
 
-### Live quizzes — planned (host)
+### Live quizzes — planned (host only; the learner self-check is on `main`)
 
 Per-section retrieval questions ship as a portable bank in
-[`quiz/`](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz)
-(facilitator and participant Markdown export; no live host).
-The architecture spike evaluated three FOSS live-host candidates and **adopted
-none of them (0/3)** — so the self-hosted live quiz add-on remains **planned**,
-with host architecture still open.
+[`quiz/`](https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz),
+and learners answer them today in the
+[static self-check quiz](https://platformrelay.github.io/Kubernetes-Workshop/quiz/)
+published beside the decks — no host, no account, no backend, nothing stored.
+That player is a **self-check, not an exam**: the answers ship inside the static
+files, and the workshop does not claim otherwise
+([ADR 0015](./decisions/0015-static-self-check-quiz-player.md)). The printable
+facilitator/participant Markdown export stays the offline and show-of-hands path.
+
+What remains direction is the **live room** picture — one facilitator seeing how
+the room answered. The architecture spike evaluated three FOSS live-host
+candidates and **adopted none of them (0/3)**, so the self-hosted live quiz
+add-on remains **planned**, with host architecture still open.
 
 [Discuss live quizzes →](https://github.com/PlatformRelay/Kubernetes-Workshop/discussions/21)
 

--- a/quiz/README.md
+++ b/quiz/README.md
@@ -4,6 +4,10 @@ This directory is the candidate-neutral source for workshop quizzes. It is not e
 Slidev. A live quiz host is still out of scope (US-QUIZ-3) until a FOSS runtime passes the
 license gate.
 
+Learners answer these questions in the **static self-check player** published at
+<https://platformrelay.github.io/Kubernetes-Workshop/quiz/> — see
+[the player](#static-self-check-player) below.
+
 - `questions.schema.json` documents schema version 1.
 - `questions.json` is the reviewed bank: at least two questions per authored section
   (canonical and optional). Deferred `S24` is excluded until that section is teachable.
@@ -11,23 +15,62 @@ license gate.
 - Correct answers, explanations, distractor rationales, learning objectives, and currency references
   live in the repository, not in a quiz vendor's database.
 
-Run the bank gates and offline fallback with:
+Run the bank gates, the player build, and the offline fallback with:
 
 ```sh
 node scripts/quiz/validate.mjs
 node --test scripts/quiz/quiz.test.mjs
 node scripts/quiz/license-gate.mjs docs/decisions/evidence/0011-live-quiz-spike/candidates.json
 node scripts/quiz/export.mjs --out dist-quiz
+node scripts/quiz/build-player.mjs --out dist-quiz/player
 node scripts/quiz/rehearse-offline.mjs --out dist-quiz --timestamp 2026-08-04T00:06:23+02:00
 ```
+
+## Static self-check player
+
+`player/` is a zero-dependency browser player: plain HTML, CSS, and ES modules, with **no npm or
+Python runtime dependency, no CDN script, no webfont, and no third-party origin**. It is published
+at `/quiz/` on the GitHub Pages artifact, as a sibling of `/deck/`, by
+`node scripts/quiz/build-player.mjs --out site/quiz` inside
+[`scripts/pages-build.sh`](../scripts/pages-build.sh).
+
+- `player/logic.mjs` holds every decision as pure functions — grading, `#SNN` deep-link resolution,
+  and the session walk. `node --test` imports it and drives the real learner journey.
+- `player/app.mjs` is thin DOM wiring on top of that module and nothing else.
+- The build copies `questions.json` in verbatim and derives the section index (titles, day, status)
+  from `scripts/deck-manifest.mjs`, so this directory stays the source of truth.
+
+What the player does:
+
+- Choosing an option **locks** the question, marks chosen against correct, always shows the
+  `explanation`, and on a wrong pick also shows that option's `rationale` — the "why was this
+  tempting?" answer a printed key cannot give you. "Show all rationales" is an explicit opt-in.
+- The landing page groups **authored** sections by workshop day using the deck-manifest titles.
+  Deferred `S24` is not offered, and a `#SNN` link to a section with no questions falls back to the
+  landing page with an explanation rather than a blank screen.
+- `#S05` deep-links straight into one section.
+
+What it deliberately does not do:
+
+- **It is not an exam and claims no exam security.** Every answer, explanation, and rationale ships
+  in the static files next to the page; anyone can read them. A score is feedback for the learner
+  alone, never proof of anything to anyone else, and no obfuscation will be added to pretend
+  otherwise — see [ADR 0015](../docs/decisions/0015-static-self-check-quiz-player.md).
+- **Nothing is stored or sent.** The score lives in the tab for as long as the tab does: no
+  `localStorage`, no cookie, no account, no telemetry, no central collection. Reload and it is gone.
+- **It does not show a room how it answered.** That is the live-host question, still open under
+  [ADR 0011](../docs/decisions/0011-live-quiz-spike.md) and US-QUIZ-3. Facilitators keep the
+  Markdown facilitator copy for a show of hands.
 
 AJV enforces `questions.schema.json`; the validator then applies semantic relationships that JSON Schema
 does not express, including known section membership, unique IDs, answer-to-option references, and a
 coverage gate of at least two questions per authored section.
 
-The export command creates separate participant and facilitator Markdown plus a non-production adapter
-preview. Participant output deliberately omits answers. The facilitator output can be printed or used
-for a show-of-hands fallback when a live service or venue internet is unavailable.
+The export command creates separate participant and facilitator Markdown, a copy of the static
+player under `player/`, plus a non-production adapter preview. Participant output deliberately omits
+answers. The facilitator output can be printed or used for a show-of-hands fallback when a live
+service or venue internet is unavailable; it remains the offline path and is not replaced by the
+browser player.
 
 The rehearsal command replays validation and export, records input/output hashes, checks reveal separation,
 and verifies deterministic offline reset. A committed example from the US-QUIZ-1 spike lives in the ADR

--- a/quiz/player/app.mjs
+++ b/quiz/player/app.mjs
@@ -1,0 +1,285 @@
+// DOM wiring for the static self-check quiz player.
+//
+// Deliberately thin: every decision (grading, deep-link resolution, session
+// walk) lives in `logic.mjs`, which `node --test` exercises directly. This file
+// only turns those values into elements and turns clicks back into values.
+//
+// It exports `boot()` and only self-starts in a browser, so Node can import it
+// as a load-time smoke check without a DOM.
+
+import {
+  advance,
+  advanceLabel,
+  createSession,
+  currentQuestion,
+  currentResult,
+  isLocked,
+  recordAnswer,
+  resolveView,
+  restart,
+  sessionScore,
+  visibleRationales,
+} from './logic.mjs'
+
+const element = id => document.getElementById(id)
+
+const state = {
+  sections: [],
+  questions: [],
+  session: null,
+  sectionId: null,
+  showAll: false,
+}
+
+function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild)
+}
+
+function make(tag, { text, className, attributes } = {}) {
+  const node = document.createElement(tag)
+  if (text !== undefined) node.textContent = text
+  if (className) node.className = className
+  for (const [name, value] of Object.entries(attributes ?? {})) node.setAttribute(name, value)
+  return node
+}
+
+// --- landing -----------------------------------------------------------------
+
+function renderLanding(view) {
+  const notice = element('notice')
+  notice.textContent = view.notice ?? ''
+  notice.hidden = !view.notice
+
+  const days = element('days')
+  clear(days)
+  for (const group of view.days) {
+    days.append(make('h3', { text: `Day ${group.day}` }))
+    const list = make('ul', { className: 'section-list' })
+    for (const section of group.sections) {
+      const link = make('a', {
+        attributes: {
+          href: `#${section.id}`,
+          'data-testid': 'section-link',
+          'data-section': section.id,
+        },
+      })
+      link.append(make('span', { text: section.id, className: 'id' }))
+      link.append(make('span', { text: section.title, className: 'title' }))
+      link.append(make('span', {
+        text: `${section.count} question${section.count === 1 ? '' : 's'}`,
+        className: 'count',
+      }))
+      const item = document.createElement('li')
+      item.append(link)
+      list.append(item)
+    }
+    days.append(list)
+  }
+
+  element('landing').hidden = false
+  element('quiz').hidden = true
+}
+
+// --- one question ------------------------------------------------------------
+
+function optionState(result, optionId) {
+  if (!result) return 'idle'
+  if (optionId === result.answerId) return optionId === result.chosenId ? 'correct' : 'answer'
+  return optionId === result.chosenId ? 'chosen' : 'other'
+}
+
+function renderOptions(question, result) {
+  const list = element('options')
+  clear(list)
+  for (const option of question.options) {
+    const button = make('button', {
+      attributes: {
+        type: 'button',
+        'data-testid': 'option',
+        'data-option': option.id,
+        'data-state': optionState(result, option.id),
+      },
+    })
+    button.append(make('span', { text: option.text }))
+    if (result) {
+      const marker = option.id === result.answerId
+        ? 'Correct answer'
+        : option.id === result.chosenId ? 'Your answer' : ''
+      if (marker) button.append(make('span', { text: marker, className: 'marker' }))
+      button.setAttribute('aria-disabled', 'true')
+    }
+    // A locked question ignores further clicks in `recordAnswer`; the button stays
+    // focusable and clickable so keyboard users never hit a disabled dead end.
+    button.addEventListener('click', () => answer(option.id))
+    const item = document.createElement('li')
+    item.append(button)
+    list.append(item)
+  }
+}
+
+function renderFeedback(question, result) {
+  const panel = element('feedback')
+  clear(panel)
+  if (!result) {
+    panel.hidden = true
+    panel.removeAttribute('data-correct')
+    return
+  }
+
+  panel.hidden = false
+  panel.setAttribute('data-correct', String(result.correct))
+  panel.append(make('p', {
+    text: result.correct ? 'Correct.' : 'Not quite.',
+    className: 'verdict',
+  }))
+  panel.append(make('p', { text: result.explanation }))
+
+  const rationales = visibleRationales(result, state.showAll)
+  if (rationales.length) {
+    const list = document.createElement('ul')
+    for (const entry of rationales) {
+      const item = document.createElement('li')
+      const label = entry.isAnswer ? 'Correct answer' : entry.isChosen ? 'Your answer' : 'Other option'
+      item.append(make('strong', { text: `${label} — ${entry.text} ` }))
+      item.append(document.createTextNode(entry.rationale))
+      list.append(item)
+    }
+    panel.append(list)
+  }
+
+  const references = question.references ?? []
+  if (references.length) {
+    const refs = make('p', { className: 'refs' })
+    refs.append(document.createTextNode('Reference: '))
+    references.forEach((reference, index) => {
+      if (index > 0) refs.append(document.createTextNode(' · '))
+      refs.append(make('a', {
+        text: reference,
+        attributes: { href: reference, rel: 'noopener noreferrer', target: '_blank' },
+      }))
+    })
+    panel.append(refs)
+  }
+}
+
+function renderSession() {
+  const session = state.session
+  element('landing').hidden = true
+  element('quiz').hidden = false
+  element('quiz-heading').textContent = `${session.sectionId} · ${sectionTitle(session.sectionId)}`
+
+  if (session.finished) {
+    element('question-view').hidden = true
+    element('summary').hidden = false
+    const score = sessionScore(session)
+    element('score').textContent =
+      `You got ${score.correct} out of ${score.total} — ${score.answered} answered, `
+      + `${score.total - score.answered} skipped. Nothing was recorded.`
+    return
+  }
+
+  element('summary').hidden = true
+  element('question-view').hidden = false
+
+  const question = currentQuestion(session)
+  const result = currentResult(session)
+  element('progress').textContent =
+    `Question ${session.index + 1} of ${session.questions.length}`
+  element('prompt').textContent = question.prompt
+  renderOptions(question, result)
+  renderFeedback(question, result)
+  const forward = element('advance')
+  forward.textContent = advanceLabel(session)
+  // Never disabled: the last question must always lead somewhere (a skipped
+  // question is still a way out, not a dead end).
+  forward.disabled = false
+}
+
+function sectionTitle(sectionId) {
+  return state.sections.find(section => section.id === sectionId)?.title ?? sectionId
+}
+
+// --- events ------------------------------------------------------------------
+
+function answer(optionId) {
+  if (!state.session || state.session.finished) return
+  if (isLocked(state.session)) return
+  state.session = recordAnswer(state.session, optionId)
+  renderSession()
+}
+
+function goForward() {
+  if (!state.session) return
+  if (state.session.finished) {
+    toLanding()
+    return
+  }
+  state.session = advance(state.session)
+  renderSession()
+}
+
+function toLanding() {
+  if (window.location.hash) {
+    window.location.hash = ''
+    return
+  }
+  render()
+}
+
+function render() {
+  const view = resolveView({
+    hash: window.location.hash,
+    sections: state.sections,
+    questions: state.questions,
+  })
+
+  if (view.view === 'landing') {
+    state.session = null
+    state.sectionId = null
+    renderLanding(view)
+    return
+  }
+
+  if (state.sectionId !== view.sectionId) {
+    state.sectionId = view.sectionId
+    state.session = createSession(view.questions, view.sectionId)
+  }
+  renderSession()
+}
+
+async function load(name) {
+  const response = await fetch(new URL(name, import.meta.url))
+  if (!response.ok) throw new Error(`${name} could not be loaded (${response.status})`)
+  return response.json()
+}
+
+export async function boot() {
+  const [bank, manifest] = await Promise.all([load('questions.json'), load('sections.json')])
+  state.questions = bank.questions ?? []
+  state.sections = manifest.sections ?? []
+
+  element('boot').hidden = true
+  element('advance').addEventListener('click', goForward)
+  element('to-sections').addEventListener('click', toLanding)
+  element('done').addEventListener('click', toLanding)
+  element('again').addEventListener('click', () => {
+    if (!state.session) return
+    state.session = restart(state.session)
+    renderSession()
+  })
+  element('show-all').addEventListener('change', event => {
+    state.showAll = event.target.checked
+    if (state.session && !state.session.finished) renderSession()
+  })
+  window.addEventListener('hashchange', render)
+  render()
+}
+
+function reportBootFailure(error) {
+  const boot = element('boot')
+  if (!boot) return
+  boot.hidden = false
+  boot.textContent = `The question bank could not be loaded: ${error.message}`
+}
+
+if (typeof document !== 'undefined') boot().catch(reportBootFailure)

--- a/quiz/player/index.html
+++ b/quiz/player/index.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="index, follow">
+<meta name="description" content="Self-check questions for the Kubernetes Practitioner Workshop. Pick an answer, see whether it holds, and read why.">
+<title>Self-check quiz · Kubernetes Practitioner Workshop</title>
+<link rel="stylesheet" href="player.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to the questions</a>
+
+<header class="topbar">
+  <div class="wrap">
+    <p class="eyebrow">Kubernetes Practitioner Workshop</p>
+    <h1>Self-check quiz</h1>
+    <p class="lede">
+      Pick an answer and find out straight away whether your mental model holds — with the
+      explanation, and, when you miss, why that option was tempting.
+    </p>
+  </div>
+</header>
+
+<main id="main" class="wrap">
+  <p id="boot" class="notice" role="status">Loading the question bank…</p>
+
+  <section id="landing" hidden aria-labelledby="landing-heading">
+    <h2 id="landing-heading">Pick a section</h2>
+    <p id="notice" class="notice" data-testid="notice" role="status" hidden></p>
+    <div id="days"></div>
+  </section>
+
+  <section id="quiz" hidden aria-labelledby="quiz-heading">
+    <p class="crumbs">
+      <button type="button" id="to-sections" class="link-button" data-testid="to-sections">← All sections</button>
+    </p>
+    <h2 id="quiz-heading"></h2>
+
+    <div id="question-view">
+      <p id="progress" class="progress"></p>
+      <p id="prompt" class="prompt"></p>
+      <ul id="options" class="options"></ul>
+
+      <div id="feedback" class="feedback" data-testid="feedback" role="status" hidden></div>
+
+      <p class="controls">
+        <label class="toggle">
+          <input type="checkbox" id="show-all">
+          Show all rationales
+        </label>
+        <button type="button" id="advance" class="primary" data-testid="advance"></button>
+      </p>
+    </div>
+
+    <div id="summary" hidden>
+      <p id="score" class="score" data-testid="score" role="status"></p>
+      <p class="controls">
+        <button type="button" id="again">Try this section again</button>
+        <button type="button" id="done" class="primary" data-testid="to-landing">Back to all sections</button>
+      </p>
+    </div>
+  </section>
+</main>
+
+<footer class="wrap site-footer">
+  <p>
+    <strong>This is a self-check, not an exam.</strong> The answers ship inside these static
+    files, so anyone can read them — treat your score as feedback for yourself, never as proof
+    of anything to anyone else.
+  </p>
+  <p>
+    Your answers stay in this browser tab: nothing is stored, nothing is uploaded, and there is
+    no account, backend, or telemetry. Reload the page and the score is gone.
+  </p>
+  <p>
+    Questions come from
+    <a href="https://github.com/PlatformRelay/Kubernetes-Workshop/tree/main/quiz">the workshop's
+    question bank</a>; a printable participant/facilitator copy is exported from the same source
+    for rooms without internet.
+  </p>
+</footer>
+
+<script type="module" src="app.mjs"></script>
+</body>
+</html>

--- a/quiz/player/logic.mjs
+++ b/quiz/player/logic.mjs
@@ -1,0 +1,215 @@
+// Pure logic for the static self-check quiz player.
+//
+// Everything here is a value transformation: no DOM, no network, no storage, no
+// clock. That is deliberate — `node --test` imports this module and drives the
+// real learner journey (grading, deep links, session walk) without a browser,
+// and the DOM wiring in `app.mjs` stays thin enough to read in one sitting.
+//
+// This player is a SELF-CHECK, not an exam. Answers, explanations, and
+// distractor rationales ship in the static files next to this module; anyone can
+// read them. Nothing here should ever pretend otherwise.
+
+const SECTION_ID = /^S\d{2}$/
+
+/**
+ * Read a `#S05`-style deep link. Returns a canonical section id, or `null` when
+ * the hash names no section (empty, `#`, or free text).
+ */
+export function parseSectionHash(hash) {
+  if (typeof hash !== 'string') return null
+  const raw = hash.trim().replace(/^#/, '').replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!raw) return null
+  const candidate = raw.toUpperCase()
+  return SECTION_ID.test(candidate) ? candidate : null
+}
+
+/** Questions belonging to one section, in bank order. */
+export function questionsForSection(questions, sectionId) {
+  return (questions ?? []).filter(question => question.section === sectionId)
+}
+
+function countBySection(questions) {
+  const counts = new Map()
+  for (const question of questions ?? [])
+    counts.set(question.section, (counts.get(question.section) ?? 0) + 1)
+  return counts
+}
+
+/**
+ * The landing page: authored sections that actually have questions, grouped by
+ * workshop day, titled from the deck manifest. Deferred sections (S24) and any
+ * section the bank does not cover are left out rather than offered as a dead end.
+ */
+export function groupSectionsByDay(sections, questions) {
+  const counts = countBySection(questions)
+  const groups = new Map()
+  for (const section of sections ?? []) {
+    if (section.status !== 'authored') continue
+    const count = counts.get(section.id) ?? 0
+    if (count === 0) continue
+    const day = section.day
+    if (!groups.has(day)) groups.set(day, [])
+    groups.get(day).push({ id: section.id, title: section.title, day, count })
+  }
+  return [...groups.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([day, entries]) => ({
+      day,
+      sections: entries.sort((left, right) => left.id.localeCompare(right.id)),
+    }))
+}
+
+/**
+ * Decide what a given hash should show. The landing page is ALWAYS computed, so
+ * a hash that names nothing playable — `#S24` (deferred), an unknown id, or
+ * free text — degrades to the section list with an explanation instead of
+ * hiding both views and leaving a blank page.
+ */
+export function resolveView({ hash, sections, questions }) {
+  const days = groupSectionsByDay(sections, questions)
+  const landing = (notice = null) => ({
+    view: 'landing',
+    sectionId: null,
+    section: null,
+    questions: [],
+    days,
+    notice,
+  })
+
+  const requested = parseSectionHash(hash)
+  if (!requested) {
+    const stray = typeof hash === 'string' ? hash.trim().replace(/^#/, '') : ''
+    return landing(stray ? `“${stray}” is not a section link — pick a section below.` : null)
+  }
+
+  const section = (sections ?? []).find(candidate => candidate.id === requested) ?? null
+  if (!section)
+    return landing(`${requested} is not a section of this workshop — pick a section below.`)
+
+  const sectionQuestions = questionsForSection(questions, requested)
+  if (section.status !== 'authored' || sectionQuestions.length === 0) {
+    const reason = section.status === 'authored'
+      ? 'has no questions in the bank yet'
+      : `is ${section.status} and has no questions yet`
+    return landing(`${section.id} — ${section.title} ${reason}. Pick another section below.`)
+  }
+
+  return {
+    view: 'section',
+    sectionId: section.id,
+    section,
+    questions: sectionQuestions,
+    days,
+    notice: null,
+  }
+}
+
+/**
+ * Grade one choice. Always carries the explanation; adds the chosen option's
+ * rationale only when the learner got it wrong, because that is the moment the
+ * "why was this tempting?" answer is worth reading.
+ */
+export function grade(question, optionId) {
+  if (!question || !Array.isArray(question.options))
+    throw new TypeError('grade() needs a question with an options array')
+  const chosen = question.options.find(option => option.id === optionId)
+  if (!chosen)
+    throw new RangeError(`unknown option "${optionId}" for question ${question.id}`)
+
+  const correct = optionId === question.answer
+  return {
+    questionId: question.id,
+    chosenId: optionId,
+    answerId: question.answer,
+    correct,
+    explanation: question.explanation,
+    chosenRationale: correct ? null : chosen.rationale,
+    rationales: question.options.map(option => ({
+      id: option.id,
+      text: option.text,
+      rationale: option.rationale,
+      isAnswer: option.id === question.answer,
+      isChosen: option.id === optionId,
+    })),
+  }
+}
+
+/**
+ * Which rationales to show under a graded question. By default only the wrong
+ * pick's; "show all rationales" is an explicit opt-in.
+ */
+export function visibleRationales(result, showAll = false) {
+  if (!result) return []
+  if (showAll) return result.rationales
+  return result.rationales.filter(entry => entry.isChosen && !entry.isAnswer)
+}
+
+// --- session -----------------------------------------------------------------
+// Session state is a plain value held in memory for the length of one page view.
+// Nothing is persisted: no browser storage, no cookie, no upload.
+
+export function createSession(questions, sectionId = null) {
+  const list = [...(questions ?? [])]
+  return {
+    sectionId,
+    questions: list,
+    index: 0,
+    results: list.map(() => null),
+    finished: false,
+  }
+}
+
+export function currentQuestion(session) {
+  return session.questions[session.index] ?? null
+}
+
+export function currentResult(session) {
+  return session.results[session.index] ?? null
+}
+
+export function isLocked(session) {
+  return currentResult(session) !== null
+}
+
+export function isLastQuestion(session) {
+  return session.index >= session.questions.length - 1
+}
+
+/** First answer wins: a locked question keeps its verdict. */
+export function recordAnswer(session, optionId) {
+  if (session.finished) return session
+  const question = currentQuestion(session)
+  if (!question || session.results[session.index]) return session
+  const results = [...session.results]
+  results[session.index] = grade(question, optionId)
+  return { ...session, results }
+}
+
+/**
+ * Move forward. On the last question this FINISHES the session rather than
+ * refusing to move — the forward control must never become a dead end.
+ */
+export function advance(session) {
+  if (session.finished) return session
+  if (isLastQuestion(session)) return { ...session, finished: true }
+  return { ...session, index: session.index + 1 }
+}
+
+/** The forward control's label. Never empty, in any state. */
+export function advanceLabel(session) {
+  if (session.finished) return 'Back to sections'
+  return isLastQuestion(session) ? 'See your score' : 'Next question'
+}
+
+export function sessionScore(session) {
+  const answered = session.results.filter(Boolean)
+  return {
+    answered: answered.length,
+    correct: answered.filter(result => result.correct).length,
+    total: session.questions.length,
+  }
+}
+
+export function restart(session) {
+  return createSession(session.questions, session.sectionId)
+}

--- a/quiz/player/player.css
+++ b/quiz/player/player.css
@@ -1,0 +1,200 @@
+/* Self-check quiz player — zero dependencies, no webfonts, no external assets. */
+
+:root {
+  color-scheme: light dark;
+  --ink: #16181d;
+  --ink-soft: #4c5361;
+  --paper: #f7f8fa;
+  --card: #ffffff;
+  --line: #d9dee6;
+  --accent: #3949ab;
+  --accent-ink: #ffffff;
+  --right: #1b7f4b;
+  --right-bg: #e7f6ed;
+  --wrong: #b3261e;
+  --wrong-bg: #fdecea;
+  --radius: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e8eaee;
+    --ink-soft: #a8b0bd;
+    --paper: #14161a;
+    --card: #1c1f25;
+    --line: #333944;
+    --accent: #8c9eff;
+    --accent-ink: #14161a;
+    --right: #6ede9e;
+    --right-bg: #163224;
+    --wrong: #ff9a90;
+    --wrong-bg: #341c1a;
+  }
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+[hidden] { display: none !important; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font: 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.wrap { max-width: 46rem; margin: 0 auto; padding: 0 1.25rem; }
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--card);
+  border: 2px solid var(--accent);
+  border-radius: var(--radius);
+  z-index: 10;
+}
+
+.topbar {
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  padding: 1.75rem 0 1.5rem;
+}
+.eyebrow {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.topbar h1 { margin: 0.25rem 0 0.5rem; font-size: 1.75rem; }
+.lede { margin: 0; color: var(--ink-soft); max-width: 38rem; }
+
+main { padding: 1.75rem 0 2.5rem; }
+
+h2 { font-size: 1.25rem; margin: 0 0 0.75rem; }
+h3 { font-size: 0.85rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-soft); margin: 1.5rem 0 0.5rem; }
+
+.notice {
+  margin: 0 0 1.25rem;
+  padding: 0.75rem 1rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  color: var(--ink-soft);
+}
+
+.section-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.5rem; }
+@media (min-width: 40rem) {
+  .section-list { grid-template-columns: 1fr 1fr; }
+}
+
+.section-list a {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: inherit;
+  text-decoration: none;
+}
+.section-list a:hover, .section-list a:focus-visible { border-color: var(--accent); }
+.section-list .id { font-variant-numeric: tabular-nums; color: var(--ink-soft); font-size: 0.85rem; }
+.section-list .count { color: var(--ink-soft); font-size: 0.8rem; white-space: nowrap; }
+.section-list .title { flex: 1 1 auto; }
+
+.crumbs { margin: 0 0 0.75rem; }
+.link-button {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.progress { margin: 0 0 0.5rem; color: var(--ink-soft); font-size: 0.9rem; }
+.prompt { margin: 0 0 1rem; font-size: 1.05rem; }
+
+.options { list-style: none; margin: 0 0 1rem; padding: 0; display: grid; gap: 0.5rem; }
+.options button {
+  width: 100%;
+  text-align: left;
+  padding: 0.7rem 0.9rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.options button:hover:not([aria-disabled="true"]) { border-color: var(--accent); }
+.options button[aria-disabled="true"] { cursor: default; }
+.options button[data-state="correct"],
+.options button[data-state="answer"] {
+  border-color: var(--right);
+  background: var(--right-bg);
+}
+.options button[data-state="chosen"] {
+  border-color: var(--wrong);
+  background: var(--wrong-bg);
+}
+.options .marker { font-size: 0.8rem; color: var(--ink-soft); display: block; }
+
+.feedback {
+  margin: 0 0 1rem;
+  padding: 0.9rem 1rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+.feedback .verdict { margin: 0 0 0.5rem; font-weight: 600; }
+.feedback[data-correct="true"] .verdict { color: var(--right); }
+.feedback[data-correct="false"] .verdict { color: var(--wrong); }
+.feedback p { margin: 0 0 0.5rem; }
+.feedback ul { margin: 0.25rem 0 0.5rem; padding-left: 1.1rem; }
+.feedback li { margin-bottom: 0.35rem; }
+.feedback .refs { font-size: 0.85rem; color: var(--ink-soft); }
+.feedback a { color: var(--accent); }
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0;
+}
+.toggle { color: var(--ink-soft); font-size: 0.9rem; display: inline-flex; gap: 0.4rem; align-items: center; }
+
+button {
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+button.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-ink); }
+
+.score { font-size: 1.1rem; margin: 0 0 1rem; }
+
+.site-footer {
+  border-top: 1px solid var(--line);
+  padding-top: 1.25rem;
+  padding-bottom: 2.5rem;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+.site-footer a { color: var(--accent); }
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/scripts/pages-build.sh
+++ b/scripts/pages-build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Build the GitHub Pages tree locally: MkDocs landing + Slidev decks under /deck/.
+# Build the GitHub Pages tree locally: MkDocs landing, Slidev decks under /deck/,
+# and the static self-check quiz player under /quiz/.
 # Mirrors .github/workflows/pages.yml (BASE defaults to /Kubernetes-Workshop).
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -63,5 +64,10 @@ cat >"${SITE}/templates/index.html" <<'EOF'
 <p><a href="../deck/templates/">Continue to the template gallery</a></p>
 </html>
 EOF
+
+# Static self-check quiz player (US-QUIZ-4). Zero dependencies; the bank in
+# quiz/questions.json stays the source of truth and is copied in verbatim.
+echo "==> quiz self-check player → ${SITE}/quiz"
+node scripts/quiz/build-player.mjs --out "${SITE}/quiz"
 
 echo "Pages tree ready at ${SITE}/ (pnpm pages:preview serves it)"

--- a/scripts/pages-site.test.mjs
+++ b/scripts/pages-site.test.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 // Assert Pages workflow / build script keep Slidev under /deck/ with hash routing.
-import { readFileSync, existsSync } from 'node:fs'
-import { resolve, dirname } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, existsSync, mkdtempSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { resolve, dirname, join, extname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import assert from 'node:assert/strict'
 import test from 'node:test'
@@ -35,4 +38,141 @@ test('docs landing and run-slides exist', () => {
 
 test('public roadmap page exists for MkDocs', () => {
   assert.ok(existsSync(resolve(ROOT, 'docs/roadmap.md')))
+})
+
+// ---------------------------------------------------------------------------
+// US-QUIZ-4 — the static self-check player is published at /quiz/.
+//
+// These tests build the real tree with the same script `pages-build.sh` runs and
+// then drive it in a browser, rather than asserting on the shell script's text.
+// ---------------------------------------------------------------------------
+
+const PLAYER_ASSETS = ['index.html', 'player.css', 'app.mjs', 'logic.mjs', 'questions.json', 'sections.json']
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+}
+
+// Minimal localhost file server: ES modules and fetch() both need an http origin,
+// so the built tree is served exactly as GitHub Pages would serve it.
+function serveStatic(rootDirectory) {
+  const rootDir = resolve(rootDirectory)
+  const server = createServer((request, response) => {
+    const url = request.url.split('?')[0].split('#')[0]
+    const requested = resolve(rootDir, `.${decodeURIComponent(url)}`)
+    const file = url === '/' || url === '' ? join(rootDir, 'index.html') : requested
+    if (file !== rootDir && !file.startsWith(rootDir + '/')) {
+      response.writeHead(403)
+      response.end('forbidden')
+      return
+    }
+    if (!existsSync(file)) {
+      response.writeHead(404)
+      response.end('missing')
+      return
+    }
+    response.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' })
+    response.end(readFileSync(file))
+  })
+  return new Promise((resolvePromise) => {
+    server.listen(0, '127.0.0.1', () => resolvePromise({ server, port: server.address().port }))
+  })
+}
+
+function buildQuizTree() {
+  const directory = mkdtempSync(join(tmpdir(), 'pages-quiz-'))
+  execFileSync(process.execPath, [resolve(ROOT, 'scripts/quiz/build-player.mjs'), '--out', directory], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  })
+  return directory
+}
+
+test('build-player.mjs emits a complete /quiz/ tree', () => {
+  const directory = buildQuizTree()
+  for (const asset of PLAYER_ASSETS)
+    assert.ok(existsSync(join(directory, asset)), `built quiz tree is missing ${asset}`)
+
+  const bank = JSON.parse(readFileSync(resolve(ROOT, 'quiz/questions.json'), 'utf8'))
+  const shipped = JSON.parse(readFileSync(join(directory, 'questions.json'), 'utf8'))
+  assert.deepEqual(
+    shipped.questions.map(question => question.id),
+    bank.questions.map(question => question.id),
+  )
+  const html = readFileSync(join(directory, 'index.html'), 'utf8')
+  assert.match(html, /<script[^>]+type="module"[^>]+src="app\.mjs"/)
+})
+
+test('pages-build.sh publishes the built player under the site tree', () => {
+  const sh = readFileSync(resolve(ROOT, 'scripts/pages-build.sh'), 'utf8')
+  assert.match(sh, /scripts\/quiz\/build-player\.mjs/)
+  assert.match(sh, /\$\{SITE\}\/quiz/)
+})
+
+test('the published player answers, explains, finishes, and returns to the landing page', { timeout: 120_000 }, async () => {
+  const directory = buildQuizTree()
+  const bank = JSON.parse(readFileSync(resolve(ROOT, 'quiz/questions.json'), 'utf8'))
+  const { chromium } = await import('playwright-chromium')
+  const { server, port } = await serveStatic(directory)
+  const browser = await chromium.launch()
+  try {
+    const page = await browser.newPage()
+    const origin = `http://127.0.0.1:${port}`
+
+    // Landing page: authored sections grouped by day, deferred S24 absent.
+    await page.goto(`${origin}/`, { waitUntil: 'networkidle' })
+    await page.waitForSelector('[data-testid="section-link"]')
+    const listed = await page.$$eval('[data-testid="section-link"]', nodes => nodes.map(node => node.dataset.section))
+    assert.ok(listed.includes('S05'))
+    assert.ok(!listed.includes('S24'), 'the deferred section must not be offered')
+
+    // A valid section id with no questions must still render the landing page.
+    await page.goto(`${origin}/#S24`, { waitUntil: 'networkidle' })
+    await page.waitForSelector('[data-testid="section-link"]')
+    assert.match(await page.textContent('[data-testid="notice"]'), /S24/)
+
+    // Deep link into one section and answer wrong: explanation + rationale.
+    const questions = bank.questions.filter(question => question.section === 'S05')
+    await page.goto(`${origin}/#S05`, { waitUntil: 'networkidle' })
+    await page.waitForSelector('[data-testid="option"]')
+    const first = questions[0]
+    const distractor = first.options.find(option => option.id !== first.answer)
+    await page.click(`[data-testid="option"][data-option="${distractor.id}"]`)
+    const feedback = await page.textContent('[data-testid="feedback"]')
+    assert.match(feedback, new RegExp(first.explanation.slice(0, 40).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    assert.match(feedback, new RegExp(distractor.rationale.slice(0, 40).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+
+    // The choice locks: a graded question is marked aria-disabled and its click
+    // handler ignores further picks, so the verdict cannot be rewritten.
+    const other = first.options.find(option => option.id !== distractor.id)
+    assert.equal(
+      await page.getAttribute(`[data-testid="option"][data-option="${other.id}"]`, 'aria-disabled'),
+      'true',
+    )
+    await page.dispatchEvent(`[data-testid="option"][data-option="${other.id}"]`, 'click')
+    assert.equal(
+      await page.getAttribute(`[data-testid="option"][data-option="${distractor.id}"]`, 'data-state'),
+      'chosen',
+    )
+
+    // Walk to the last question; the forward control is never disabled.
+    for (let index = 0; index < questions.length; index++) {
+      assert.equal(await page.isDisabled('[data-testid="advance"]'), false, 'the forward control must stay live')
+      await page.click('[data-testid="advance"]')
+    }
+
+    // The last click lands on the score, which offers the landing page back.
+    await page.waitForSelector('[data-testid="score"]')
+    assert.match(await page.textContent('[data-testid="score"]'), new RegExp(`of ${questions.length}`))
+    await page.click('[data-testid="to-landing"]')
+    await page.waitForSelector('[data-testid="section-link"]')
+  }
+  finally {
+    await browser.close()
+    server.close()
+  }
 })

--- a/scripts/pages-site.test.mjs
+++ b/scripts/pages-site.test.mjs
@@ -59,24 +59,25 @@ const MIME = {
 
 // Minimal localhost file server: ES modules and fetch() both need an http origin,
 // so the built tree is served exactly as GitHub Pages would serve it.
+//
+// The built tree is a flat, fully known set of files (PLAYER_ASSETS), so a request
+// is resolved by looking its name up in that list and serving the entry found
+// there. Nothing the request says is ever joined onto a filesystem path, which is
+// both the simplest containment guarantee for a server that runs in CI and what
+// keeps CodeQL's js/path-injection rule satisfied.
 function serveStatic(rootDirectory) {
   const rootDir = resolve(rootDirectory)
   const server = createServer((request, response) => {
     const url = request.url.split('?')[0].split('#')[0]
-    const requested = resolve(rootDir, `.${decodeURIComponent(url)}`)
-    const file = url === '/' || url === '' ? join(rootDir, 'index.html') : requested
-    if (file !== rootDir && !file.startsWith(rootDir + '/')) {
-      response.writeHead(403)
-      response.end('forbidden')
-      return
-    }
-    if (!existsSync(file)) {
+    const wanted = url === '/' || url === '' ? 'index.html' : decodeURIComponent(url).replace(/^\/+/, '')
+    const asset = PLAYER_ASSETS.find(candidate => candidate === wanted)
+    if (!asset || !existsSync(join(rootDir, asset))) {
       response.writeHead(404)
       response.end('missing')
       return
     }
-    response.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' })
-    response.end(readFileSync(file))
+    response.writeHead(200, { 'content-type': MIME[extname(asset)] ?? 'application/octet-stream' })
+    response.end(readFileSync(join(rootDir, asset)))
   })
   return new Promise((resolvePromise) => {
     server.listen(0, '127.0.0.1', () => resolvePromise({ server, port: server.address().port }))

--- a/scripts/quiz/build-player.mjs
+++ b/scripts/quiz/build-player.mjs
@@ -1,0 +1,62 @@
+// Build the static self-check quiz player tree published at /quiz/.
+//
+// The bank in `quiz/questions.json` stays the source of truth: this script only
+// copies the zero-dependency player next to a verbatim copy of the bank plus a
+// small section index derived from the deck manifest, so the browser never has
+// to import Node-only modules. `scripts/pages-build.sh` runs exactly this, which
+// is what makes the Pages layout testable without rebuilding the whole site.
+
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { sections as deckSections } from '../deck-manifest.mjs'
+
+export const PLAYER_ASSETS = ['index.html', 'player.css', 'app.mjs', 'logic.mjs']
+
+const repoRoot = path.resolve(import.meta.dirname, '../..')
+
+/**
+ * Emit the complete player tree into `outDir`.
+ *
+ * The section index ships EVERY section with its manifest status, not just the
+ * authored ones: the player filters, and a deep link to a section without
+ * questions (`#S24`) can then explain itself instead of rendering nothing.
+ */
+export function buildPlayer({ outDir, root = repoRoot } = {}) {
+  if (!outDir) throw new Error('buildPlayer needs an outDir')
+  const outputDirectory = path.resolve(outDir)
+  mkdirSync(outputDirectory, { recursive: true })
+
+  for (const asset of PLAYER_ASSETS)
+    copyFileSync(path.join(root, 'quiz/player', asset), path.join(outputDirectory, asset))
+
+  const bank = JSON.parse(readFileSync(path.join(root, 'quiz/questions.json'), 'utf8'))
+  writeFileSync(path.join(outputDirectory, 'questions.json'), `${JSON.stringify(bank, null, 2)}\n`)
+
+  const sections = deckSections.map(({ id, title, day, status }) => ({ id, title, day, status }))
+  writeFileSync(
+    path.join(outputDirectory, 'sections.json'),
+    `${JSON.stringify({ sections }, null, 2)}\n`,
+  )
+
+  return {
+    outputDirectory,
+    assets: [...PLAYER_ASSETS, 'questions.json', 'sections.json'],
+    questionCount: bank.questions.length,
+    sectionCount: sections.length,
+  }
+}
+
+const invokedDirectly = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (invokedDirectly) {
+  const outFlag = process.argv.indexOf('--out')
+  if (outFlag < 0 || !process.argv[outFlag + 1])
+    throw new Error('usage: build-player.mjs --out DIRECTORY')
+  const result = buildPlayer({ outDir: process.argv[outFlag + 1] })
+  process.stdout.write(
+    `Built the self-check quiz player (${result.questionCount} questions, `
+    + `${result.sectionCount} sections) in ${result.outputDirectory}.\n`,
+  )
+}

--- a/scripts/quiz/export.mjs
+++ b/scripts/quiz/export.mjs
@@ -1,5 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { buildPlayer } from './build-player.mjs'
 
 const root = path.resolve(import.meta.dirname, '../..')
 const outFlag = process.argv.indexOf('--out')
@@ -42,4 +43,11 @@ const preview = {
   },
 }
 writeFileSync(path.join(outputDirectory, 'adapter-preview.json'), `${JSON.stringify(preview, null, 2)}\n`)
+
+// The static self-check player ships beside the Markdown copies rather than
+// replacing them: the browser player needs a host to serve it, the Markdown does
+// not. The stdout line below is deliberately unchanged — the committed ADR-0011
+// rehearsal transcript quotes it verbatim.
+buildPlayer({ outDir: path.join(outputDirectory, 'player') })
+
 process.stdout.write(`Exported offline participant/facilitator copies and adapter preview to ${outputDirectory}.\n`)

--- a/scripts/quiz/quiz.test.mjs
+++ b/scripts/quiz/quiz.test.mjs
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
+import { pathToFileURL } from 'node:url'
 import { gunzipSync, gzipSync } from 'node:zlib'
 import { sections as deckSections } from '../deck-manifest.mjs'
 
@@ -424,4 +425,249 @@ test('CI enforces quiz schema, license, and rehearsal contracts', () => {
   assert.match(workflow, /pnpm run quiz:validate/)
   assert.match(workflow, /pnpm run quiz:license-gate/)
   assert.match(workflow, /pnpm run test:quiz/)
+})
+
+// ---------------------------------------------------------------------------
+// US-QUIZ-4 — static self-check player.
+//
+// These tests EXECUTE the player's pure core (`quiz/player/logic.mjs`) against
+// the real bank and the real deck manifest. They deliberately do not settle for
+// "the file exists": every branch a learner can reach is driven here.
+// ---------------------------------------------------------------------------
+
+const playerLogic = await import(pathToFileURL(path.join(root, 'quiz/player/logic.mjs')).href)
+const playerSections = deckSections.map(({ id, title, day, status }) => ({ id, title, day, status }))
+const bank = JSON.parse(readFileSync(questionsPath, 'utf8'))
+
+test('every player module imports cleanly under Node (no stray tokens at load time)', async () => {
+  for (const asset of ['logic.mjs', 'app.mjs']) {
+    const module = await import(pathToFileURL(path.join(root, 'quiz/player', asset)).href)
+    assert.equal(typeof module, 'object')
+  }
+})
+
+test('grade() always returns the explanation and adds the distractor rationale only when wrong', () => {
+  for (const question of bank.questions) {
+    const right = playerLogic.grade(question, question.answer)
+    assert.equal(right.correct, true)
+    assert.equal(right.answerId, question.answer)
+    assert.equal(right.explanation, question.explanation)
+    assert.equal(right.chosenRationale, null, `${question.id}: a correct pick must not scold with a rationale`)
+
+    for (const option of question.options.filter(candidate => candidate.id !== question.answer)) {
+      const wrong = playerLogic.grade(question, option.id)
+      assert.equal(wrong.correct, false)
+      assert.equal(wrong.chosenId, option.id)
+      assert.equal(wrong.answerId, question.answer)
+      assert.equal(wrong.explanation, question.explanation)
+      assert.equal(wrong.chosenRationale, option.rationale, `${question.id}/${option.id}: wrong picks must explain the temptation`)
+      const chosen = wrong.rationales.find(entry => entry.isChosen)
+      const answer = wrong.rationales.find(entry => entry.isAnswer)
+      assert.equal(chosen.id, option.id)
+      assert.equal(answer.id, question.answer)
+      assert.equal(wrong.rationales.length, question.options.length)
+    }
+  }
+})
+
+test('grade() refuses an option that is not on the question instead of silently scoring it', () => {
+  const question = bank.questions[0]
+  assert.throws(() => playerLogic.grade(question, 'not-an-option'), /unknown option/)
+  assert.throws(() => playerLogic.grade(undefined, 'a'), TypeError)
+})
+
+test('"show all rationales" is opt-in and never hides the wrong pick', () => {
+  const question = bank.questions[0]
+  const distractor = question.options.find(option => option.id !== question.answer)
+  const wrong = playerLogic.grade(question, distractor.id)
+  assert.deepEqual(playerLogic.visibleRationales(wrong, false).map(entry => entry.id), [distractor.id])
+  assert.equal(playerLogic.visibleRationales(wrong, true).length, question.options.length)
+
+  const right = playerLogic.grade(question, question.answer)
+  assert.deepEqual(playerLogic.visibleRationales(right, false), [])
+  assert.equal(playerLogic.visibleRationales(right, true).length, question.options.length)
+})
+
+test('hash deep links filter the bank to one section', () => {
+  assert.equal(playerLogic.parseSectionHash('#S05'), 'S05')
+  assert.equal(playerLogic.parseSectionHash('#/S05'), 'S05')
+  assert.equal(playerLogic.parseSectionHash('#s05'), 'S05')
+  assert.equal(playerLogic.parseSectionHash(''), null)
+  assert.equal(playerLogic.parseSectionHash('#'), null)
+  assert.equal(playerLogic.parseSectionHash('#not-a-section'), null)
+
+  const view = playerLogic.resolveView({ hash: '#S05', sections: playerSections, questions: bank.questions })
+  assert.equal(view.view, 'section')
+  assert.equal(view.sectionId, 'S05')
+  assert.equal(view.section.title, deckSections.find(section => section.id === 'S05').title)
+  assert.ok(view.questions.length > 0)
+  assert.ok(view.questions.every(question => question.section === 'S05'))
+  assert.deepEqual(
+    view.questions.map(question => question.id),
+    bank.questions.filter(question => question.section === 'S05').map(question => question.id),
+  )
+})
+
+test('a section with no questions falls back to a rendered landing page, never a blank one', () => {
+  const probes = [...deckSections.map(section => `#${section.id}`), '#S99', '#not-a-section', '', '#']
+  for (const hash of probes) {
+    const view = playerLogic.resolveView({ hash, sections: playerSections, questions: bank.questions })
+    if (view.view === 'section') {
+      assert.ok(view.questions.length > 0, `${hash} opened a section with no questions`)
+      continue
+    }
+    assert.equal(view.view, 'landing')
+    assert.ok(view.days.length > 0, `${hash} produced a landing page with nothing on it`)
+  }
+
+  const deferred = playerLogic.resolveView({ hash: '#S24', sections: playerSections, questions: bank.questions })
+  assert.equal(deferred.view, 'landing')
+  assert.ok(deferred.days.length > 0)
+  assert.match(deferred.notice, /S24/)
+  assert.match(deferred.notice, /deferred|no questions/i)
+
+  const unknown = playerLogic.resolveView({ hash: '#S99', sections: playerSections, questions: bank.questions })
+  assert.equal(unknown.view, 'landing')
+  assert.match(unknown.notice, /S99/)
+})
+
+test('the landing page groups authored sections by day with manifest titles', () => {
+  const view = playerLogic.resolveView({ hash: '', sections: playerSections, questions: bank.questions })
+  assert.equal(view.view, 'landing')
+  assert.equal(view.notice, null)
+  assert.deepEqual(view.days.map(group => group.day), [1, 2, 3])
+
+  const listed = view.days.flatMap(group => group.sections)
+  assert.equal(listed.length, deckSections.filter(section => section.status === 'authored').length)
+  assert.ok(!listed.some(section => section.id === 'S24'), 'deferred S24 must not be offered')
+  for (const entry of listed) {
+    const manifest = deckSections.find(section => section.id === entry.id)
+    assert.equal(entry.title, manifest.title)
+    assert.equal(entry.day, manifest.day)
+    assert.equal(entry.count, bank.questions.filter(question => question.section === entry.id).length)
+    assert.ok(entry.count > 0)
+  }
+  for (const group of view.days)
+    assert.ok(group.sections.every(section => section.day === group.day))
+})
+
+test('a session locks the first answer, scores in memory, and always offers a way forward', () => {
+  const questions = bank.questions.filter(question => question.section === 'S05')
+  let session = playerLogic.createSession(questions, 'S05')
+  assert.equal(playerLogic.sessionScore(session).total, questions.length)
+
+  const seen = []
+  while (!session.finished) {
+    const question = playerLogic.currentQuestion(session)
+    assert.ok(question, 'a live session must always have a current question')
+    assert.notEqual(playerLogic.advanceLabel(session), '', 'the forward control must never lose its label')
+    seen.push(question.id)
+
+    session = playerLogic.recordAnswer(session, question.answer)
+    assert.equal(playerLogic.currentResult(session).correct, true)
+    assert.equal(playerLogic.isLocked(session), true)
+
+    const distractor = question.options.find(option => option.id !== question.answer)
+    const relocked = playerLogic.recordAnswer(session, distractor.id)
+    assert.equal(relocked.results[relocked.index].chosenId, question.answer, 'the first answer must stand')
+
+    session = playerLogic.advance(session)
+    assert.ok(seen.length <= questions.length, 'advance must terminate')
+  }
+
+  assert.deepEqual(seen, questions.map(question => question.id))
+  assert.equal(session.finished, true)
+  assert.deepEqual(playerLogic.sessionScore(session), {
+    answered: questions.length,
+    correct: questions.length,
+    total: questions.length,
+  })
+})
+
+test('the last question finishes the session instead of dead-ending it', () => {
+  const questions = bank.questions.filter(question => question.section === 'S07')
+  let session = playerLogic.createSession(questions, 'S07')
+  while (!playerLogic.isLastQuestion(session)) session = playerLogic.advance(session)
+
+  assert.equal(playerLogic.isLastQuestion(session), true)
+  assert.equal(session.finished, false)
+  assert.match(playerLogic.advanceLabel(session), /\S/)
+
+  const finished = playerLogic.advance(session)
+  assert.equal(finished.finished, true, 'advancing past the last question must finish, not stall')
+  assert.match(playerLogic.advanceLabel(finished), /\S/)
+  assert.equal(playerLogic.advance(finished).finished, true, 'a finished session stays finished')
+
+  const restarted = playerLogic.restart(finished)
+  assert.equal(restarted.finished, false)
+  assert.equal(restarted.index, 0)
+  assert.equal(playerLogic.sessionScore(restarted).answered, 0)
+})
+
+test('a wrong run scores honestly and keeps every explanation reachable', () => {
+  const questions = bank.questions.filter(question => question.section === 'S10')
+  let session = playerLogic.createSession(questions, 'S10')
+  while (!session.finished) {
+    const question = playerLogic.currentQuestion(session)
+    const distractor = question.options.find(option => option.id !== question.answer)
+    session = playerLogic.recordAnswer(session, distractor.id)
+    const result = playerLogic.currentResult(session)
+    assert.equal(result.correct, false)
+    assert.equal(result.explanation, question.explanation)
+    assert.equal(result.chosenRationale, distractor.rationale)
+    session = playerLogic.advance(session)
+  }
+  assert.deepEqual(playerLogic.sessionScore(session), {
+    answered: questions.length,
+    correct: 0,
+    total: questions.length,
+  })
+})
+
+test('the player keeps no storage, no telemetry, and no backend call', () => {
+  for (const asset of ['index.html', 'player.css', 'app.mjs', 'logic.mjs']) {
+    const source = readFileSync(path.join(root, 'quiz/player', asset), 'utf8')
+    assert.doesNotMatch(source, /localStorage|sessionStorage|indexedDB|document\.cookie/, `${asset} must stay session-only`)
+    assert.doesNotMatch(source, /navigator\.sendBeacon|XMLHttpRequest|WebSocket|gtag|analytics/i, `${asset} must not phone home`)
+    assert.doesNotMatch(source, /https?:\/\/(?!kubernetes\.io|platformrelay\.github\.io|github\.com)/, `${asset} must not load third-party origins`)
+  }
+})
+
+test('the exported player ships the bank, the manifest titles, and every explanation', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'quiz-player-'))
+  run('scripts/quiz/export.mjs', ['--out', directory])
+  const playerDirectory = path.join(directory, 'player')
+
+  for (const asset of ['index.html', 'player.css', 'app.mjs', 'logic.mjs', 'questions.json', 'sections.json'])
+    assert.ok(existsSync(path.join(playerDirectory, asset)), `exported player is missing ${asset}`)
+
+  const html = readFileSync(path.join(playerDirectory, 'index.html'), 'utf8')
+  assert.match(html, /app\.mjs/)
+  assert.match(html, /player\.css/)
+  assert.match(html, /not an exam|answers ship/i, 'the player must not over-claim exam security')
+
+  const exported = JSON.parse(readFileSync(path.join(playerDirectory, 'questions.json'), 'utf8'))
+  assert.deepEqual(
+    exported.questions.map(question => question.id),
+    bank.questions.map(question => question.id),
+  )
+  for (const question of bank.questions) {
+    const shipped = exported.questions.find(candidate => candidate.id === question.id)
+    assert.equal(shipped.explanation, question.explanation)
+    assert.equal(shipped.answer, question.answer)
+    assert.deepEqual(shipped.options.map(option => option.rationale), question.options.map(option => option.rationale))
+  }
+
+  const shippedSections = JSON.parse(readFileSync(path.join(playerDirectory, 'sections.json'), 'utf8')).sections
+  assert.deepEqual(shippedSections.map(section => section.id), deckSections.map(section => section.id))
+  for (const section of shippedSections) {
+    const manifest = deckSections.find(candidate => candidate.id === section.id)
+    assert.equal(section.title, manifest.title)
+    assert.equal(section.day, manifest.day)
+    assert.equal(section.status, manifest.status)
+  }
+
+  // The Markdown show-of-hands fallback survives alongside the player.
+  assert.ok(existsSync(path.join(directory, 'participant.md')))
+  assert.ok(existsSync(path.join(directory, 'facilitator.md')))
 })


### PR DESCRIPTION
## What US-QUIZ-4 delivers

A **zero-dependency static self-check quiz player**, published as a sibling of `/deck/` on the
Pages artifact we already build: `<pages-url>/quiz/`.

The reviewed bank has carried 54 questions with answers, explanations, and per-distractor
rationales since US-QUIZ-2, but the only way a learner could reach them was a printed Markdown
handout that shows the question and its answer key in the same scroll. That is a reference sheet,
not a check. This ships the retrieval-practice path: pick an option, the question locks, chosen is
marked against correct, the explanation always shows, and on a miss that option's own rationale
shows too. "Show all rationales" is an explicit opt-in.

- No npm or Python runtime dependency, no CDN script, no webfont, no third-party origin, no
  backend, no account.
- Score is session-only: no browser storage, no telemetry, no central collection. A reload clears it.
- `quiz/questions.json` stays the single source of truth. `scripts/quiz/build-player.mjs` copies it
  in verbatim and derives section titles, day grouping, and status from `deck-manifest.mjs`, so a
  new question publishes on the next Pages build with no second place to edit.
- All decision logic (grading, deep-link resolution, the session walk) lives in a pure
  `quiz/player/logic.mjs` that `node --test` imports and drives against the real bank; DOM wiring in
  `app.mjs` stays thin.
- `scripts/pages-build.sh` calls the same `build-player.mjs` the tests call, so the Pages contract
  is checked by building the tree and driving it in a browser rather than by grepping shell text.
- ADR 0015 records the choice and its load-bearing non-goal: a static page cannot keep a secret.
  The answers ship in the files, so this is a self-check and never an exam — no proctoring, no pass
  mark, no obfuscation to pretend otherwise. The player, the quiz README, and the front-door docs
  all say so plainly.

The Markdown participant/facilitator export is untouched and remains the offline and show-of-hands
path. Nothing here revives quiz-live; the live-room aggregate question stays open under ADR 0011 /
US-QUIZ-3.

## This is a rebuild

The original US-QUIZ-4 implementation was lost with a dead worktree. This branch is a **rebuild**
from the story and its acceptance criteria, not a recovery of the lost tree. Because the first
attempt's defects were known, each one was re-checked behaviourally on this implementation rather
than assumed fixed.

## The five defects are behaviourally absent, and mutation-proven

Each is covered by a test that fails when the defect is reintroduced (verified by mutation, not by
reading the code):

| # | Defect | Covering guarantee |
|---|--------|--------------------|
| **F1** | A stray token in a player module broke `import` at load time | `every player module imports cleanly under Node (no stray tokens at load time)` |
| **F2** | The Done button was dead — the last question dead-ended the session | `the last question finishes the session instead of dead-ending it` |
| **F3** | An empty or unknown section hash rendered a blank page | `a section with no questions falls back to a rendered landing page, never a blank one` |
| **F4** | The tests never actually executed the player | `the published player answers, explains, finishes, and returns to the landing page` — a real headless-Chromium run against the built `/quiz/` tree |
| **F6** | The pages assertion was text-only (it grepped the shell script instead of the artifact) | the same browser test, plus `build-player.mjs emits a complete /quiz/ tree` and `pages-build.sh publishes the built player under the site tree` |

## Review

An independent reviewer (not the author) returned **APPROVE**, with **no P0 and no P1** findings and
two **P3** notes:

- **QZ4-01** — the browser test does not assert the visible verdict text, so the pages suite *alone*
  would be blind to an inverted grade. The quiz suite does catch that case, so the behaviour is
  covered; a one-line assertion would close the layer. Tracked as follow-up, not a merge blocker.
- **QZ4-02** — the docs link `/quiz/` as live before this merge lands. Merging is what makes that
  claim true; the live URL is verified after the Pages deploy.

## Gate matrix (re-run on the rebased head)

This branch was rebased onto `e59804d` (PR #59, the advisory fix), which moved `pnpm-lock.yaml`.
Every gate was re-run after `pnpm install --frozen-lockfile` on the rebased head — earlier runs were
not trusted, because the headless-Chromium test resolves `playwright-chromium` from that lockfile.

| Gate | Result |
|------|--------|
| `pnpm test:quiz` | 25/25 pass, 0 skipped |
| `pnpm quiz:validate` | 54 questions across 27 sections |
| `pnpm quiz:export` | offline participant/facilitator copies + adapter preview |
| `pnpm test:pages` | 18/18 pass, 0 skipped — headless Chromium genuinely ran |
| `pnpm lint` | 0 issues |
| `pnpm link-check` | OK, all internal links and anchors resolve |
| `node scripts/dependency-audit.mjs` | exit 0 |

The only rebase overlap was `.github/workflows/pages.yml`; both sides' changes are present.

## Caveat

`pnpm pages:build` could **not** be run end-to-end in this environment because `mkdocs` is not
installed here. The step this change actually adds — emitting `/quiz/` into the site tree — was
verified directly instead, by building the player and driving the built artifact in a browser
(`build-player.mjs emits a complete /quiz/ tree`, `pages-build.sh publishes the built player under
the site tree`, and the end-to-end browser test). The full MkDocs + Slidev + quiz build is exercised
by the Pages workflow on merge.

## Integration fix (second commit)

Two failures appeared only once the new test ran on CI. Both were about the environment the test
runs in, not the player; neither changes the player, the bank, or the published `/quiz/` tree.

- **`Link-check front-door docs` failed** — that job ran `node --test scripts/pages-site.test.mjs`
  with no install at all, because the file used to be dependency-free (its comment said so). The
  end-to-end `/quiz/` test broke that assumption: `Cannot find package 'playwright-chromium'`. The
  job now gets `pnpm install --frozen-lockfile` and `playwright install-deps chromium`, the same as
  the deck build. Letting the test skip when Playwright is absent was the other option and is not
  one — a test that silently no-ops is exactly defect F4.
- **CodeQL failed with 2 high `js/path-injection` alerts**, both in the test's own localhost file
  server. The containment check was correct but sat downstream of a `resolve()` over request data,
  so a request still reached a filesystem path. The published tree is a flat, fully known set of
  files, so the path arithmetic is gone: the request name is looked up in `PLAYER_ASSETS` and the
  entry found there is served. Unknown names now 404 rather than 403; no test asserted on that.

Verified on CI: all 10 checks pass, and the `Link-check front-door docs` job reports
`ok 8 - the published player answers, explains, finishes, and returns to the landing page` with
`# skipped 0` — the browser test really ran.
